### PR TITLE
Add macro description; Add macro hover which shows description

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The extension adds diagnostics for erroneous usage of macros in TwineScript for 
 		```
 The following properties are currently programmed, even though not all of them are used as of now:
 - **name** `(string)` *optional*: Name of the macro (currently unused in code; the name of the object suffices for now.)
+- **description** `(string)` *optional*: Description of macro. Shown on hover.
 - **container** `(boolean)` *optional*: If the macro is a container (i.e. requires a closing tag) or not. `false` by default.
 - **selfClose** `(boolean)` *optional*: If the macro is a self-closable. Requires macro to be a container first. `false` by default.
 - **children** `(string array)` *optional*: If the macro has children, specify their names as an array (currently unused in code.)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,6 +78,10 @@ const changeStoryFormat = async function (document: vscode.TextDocument) {
 	else return new Promise(res => res(document));
 };
 
+const documentSelector: vscode.DocumentSelector = {
+	pattern: "**/*.tw*",
+};
+
 export async function activate(context: vscode.ExtensionContext) {
 	ctx = context;
 
@@ -124,9 +128,17 @@ export async function activate(context: vscode.ExtensionContext) {
 	}
 
 	ctx.subscriptions.push(
-		vscode.languages.registerDocumentSemanticTokensProvider({
-			pattern: "**/*.tw*"
-		}, new DocumentSemanticTokensProvider(), legend)
+		vscode.languages.registerDocumentSemanticTokensProvider(documentSelector, new DocumentSemanticTokensProvider(), legend)
+		,
+		vscode.languages.registerHoverProvider(documentSelector, {
+			provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
+				if (document.languageId == "twee3-sugarcube-2") {
+					return sc2m.hover(document, position);
+				} else {
+					return null;
+				}
+			}
+		})
 		,
 		vscode.window.onDidChangeTextEditorSelection(async e => {
 			if (e.textEditor.document.languageId === "twee3-sugarcube-2" && vscode.workspace.getConfiguration("twee3LanguageTools.sugarcube-2.features").get("macroTagMatching")) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,7 +95,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			vscode.workspace.getConfiguration("twee3LanguageTools.storyformat").update("current", "")
 		]);
 	}
-	
+
 	await start();
 
 	function fileGlob() {
@@ -105,7 +105,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		let files: string[] = [];
 		vscode.workspace.workspaceFolders?.forEach(el => {
 			include.forEach(elem => {
-				files = [ ...files, ...glob.sync(el.uri.fsPath + "/" + elem + "/**/*.tw*", { ignore: exclude }) ];
+				files = [...files, ...glob.sync(el.uri.fsPath + "/" + elem + "/**/*.tw*", { ignore: exclude })];
 			})
 		});
 		return files;
@@ -182,7 +182,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				});
 			}
 			if (e.affectsConfiguration("twee3LanguageTools.passage")) {
-				if (vscode.workspace.getConfiguration("twee3LanguageTools.passage").get("list"))  {
+				if (vscode.workspace.getConfiguration("twee3LanguageTools.passage").get("list")) {
 					fileGlob().forEach(file => {
 						vscode.workspace.openTextDocument(file).then(doc => parseText(ctx, doc, passageListProvider));
 					});

--- a/src/tree-view.ts
+++ b/src/tree-view.ts
@@ -28,8 +28,8 @@ export class PassageListProvider implements vscode.TreeDataProvider<Passage> {
 					if (!origins.includes(el.origin)) {
 						origins.push(el.origin);
 						const wF = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(el.origin))?.uri.path || "";
-						let p = new Passage(el.origin,  el.origin.split("/").pop() || "", vscode.TreeItemCollapsibleState.Expanded);
-						p.tooltip =  el.origin.replace(wF, "").substring(1);
+						let p = new Passage(el.origin, el.origin.split("/").pop() || "", vscode.TreeItemCollapsibleState.Expanded);
+						p.tooltip = el.origin.replace(wF, "").substring(1);
 						files.push(p);
 					}
 				});
@@ -50,8 +50,8 @@ export class PassageListProvider implements vscode.TreeDataProvider<Passage> {
 					if (!origins.includes(_origin)) {
 						origins.push(_origin);
 						const wF = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(el.origin))?.uri.path || "";
-						let p = new Passage(_origin,  _origin.replace(wF, ""), vscode.TreeItemCollapsibleState.Expanded);
-						p.tooltip =  _origin.replace(wF, "");
+						let p = new Passage(_origin, _origin.replace(wF, ""), vscode.TreeItemCollapsibleState.Expanded);
+						p.tooltip = _origin.replace(wF, "");
 						folders.push(p);
 					}
 				});
@@ -71,7 +71,7 @@ export class PassageListProvider implements vscode.TreeDataProvider<Passage> {
 					el.tags?.forEach(elem => {
 						if (!tags.includes(elem)) {
 							tags.push(elem);
-							let p = new Passage(el.origin,  elem, vscode.TreeItemCollapsibleState.Expanded);
+							let p = new Passage(el.origin, elem, vscode.TreeItemCollapsibleState.Expanded);
 							groups.push(p);
 						}
 					});


### PR DESCRIPTION
This pull-request adds a `description` field to the macro definitions in the definition files.
Then it also adds a 'hover' for macros (currently only for SugarCube2), which will display any existing description (which supports Markdown).
This would allow embedding documentation/quick-examples and, well, descriptions of what the macro is meant for. Useful for not having to look at the main documentation, and also useful when you're working on a file with others who may add their own widgets/macros.

I initially ran into some issues with determining the macro-name under the cursor, but used `collect` to acquire a list of macros and finding the entry that intersected the current position.
I imagine a more efficient implementation of collect for finding a single macro that intersects with a position could be implemented, but I don't think it is a major issue.
Example in a json file:
```json
"linkreplace": {
	"name": "linkreplace",
	"container": true,
	"description": "Creates a link that when clicked replaces itself with its content.\n\nExample: `<<linkreplace \"Say hello\">>Hi!<</linkreplace>>`"
},
```
Example in yaml file
```yaml
    thing:
      name: thing
      description: |-
        The universe revolves around this macro.

        Example: `<<thing>><</thing>>`
      container: true
```
Picture: 
![2021-01-04-181039_1120x673_scrot](https://user-images.githubusercontent.com/13157904/103592964-721c2080-4ec2-11eb-9472-2df5b3bd7675.png)


Through some effort, it will only show the description on hover of certain parts. Ex: on `<<linkreplace "Testing">>Text<</linkreplace>>`, it would only show hover on: `<<linkreplace`, `>>`, `<</linkreplace>>`. My initial version had it also show hover when you put your mouse over `"Testing"` but I felt that was undesirable and so have the more complex implementation that this pull-request is.
Note: This Pull Request does not add *any* documentation to the inbuilt SugarCube2 macros, but simple examples could be written up easily. (There's also the option of embedding the official docs as the descriptions).
Note2: It would be nice if this made the macro highlighted when it is showing the description. Currently vscode automatically highlights a 'word', but that does not match macros (ex: the 'word' for vscode stops at `-` characters, which are not uncommon in macro names).

Suggestions (These are some suggestions for the project, but perhaps should have been opened as issues):
    - Provide a testing project, either in the main repo or another repo, that exhibits a good amount of behavior. This would allow easier testing.  
    - Some of the functions (ex: sugarcube-2's 'macroList') would benefit from explicit return types as typescript fails to guess them.  
    - There are some minor formatting weirdness. Could find some formatter for VSCode and just let it auto-format?    
    - It would be nice if the extension was also uploaded to: https://github.com/eclipse/openvsx which is a vendor-neutral VSCode marketplace. (Arch-Linux's vscode uses that).