### PR TITLE
Parameter types

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Manual settings:
 - `twee3LanguageTools.sugarcube-2.warning.endMacro`: Warn about the deprecated `<<end...>>` closing tag syntax? (`true` by default.)  
 ⠀
 - `twee3LanguageTools.sugarcube-2.error.argumentParsing`: Provide errors about invalid argument syntax being passed into macros? (`true` by default.)  
+
+- `twee3LanguageTools.sugarcube-2.error.parameterValidation`: Provide errors about invalid argument types being passed into macros? (`true` by default.)  
 ⠀
 - `twee3LanguageTools.sugarcube-2.features.macroTagMatching`: Highlight opening and closing tags of container macros? (`true` by default.)  
 ⠀

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,0 +1,169 @@
+# Parameters & Arguments Validations
+In the extension, there is two steps of validations. That of parsing the arguments to the macros to ensure sanity in syntax (ex: checking for closing quotation marks on strings), and then validating the types.  
+This document goes over some high-level details of how it works, and how to use it with the extension.  
+  
+## Argument Parsing
+**Supported**: Sugarcube 2
+
+The extension uses code from SugarCube (modified in some manners) to parse the arguments faithfully. This allows for realizing errors with syntax before the script you wrote is executed by SugarCube, making so you won't accidentally run into the issue of having some obviously incorrect syntax.
+```html
+<<link "Hello!>>
+```
+Will provide a diagnostic at the end of the macro, because there is no closing quotation mark on the string and those are required.
+The same exists for Twine links that are passed as arguments, of the `[[Text->Passage]]`, `[[Passage]]`, or `[[Text|Passage]]` double-bracket form.
+```html
+<<link [Text->Passage]>>
+```
+Will provide a diagnostic at the start of the link, telling you that it is malformed.
+
+Now, this is useful and helps catch bugs, making so you have to spend less time manually loading passages for testing, but what about macros that do *fancy* custom argument parsing? Such as `<<set>>`, `<<switch>>`, `<<for>>` and more?
+These have `skipArgs` set on their definitions, example macro that doesn't want its argument's syntax to be checked (using JSON, but the same applies to YAML):
+```
+"fancy": {
+    "name": "fancy",
+    "description": "Performs fancy text manipulation!",
+    "skipArgs": true
+}
+```
+This would make so the extension does not check the arguments for validity, since the macro may be doing whatever it wants with them rather than relying on the default SugarCube argument parsing.  
+
+Thankfully, most macros use the simple argument parsing and so `skipArgs` defaults to `false` (allowing it to automatically parse them).
+
+## Parameter Types
+**Supported**: Sugarcube 2  
+
+Parameter types are a method for specifying the 'types' of the arguments that can be passed into a macro.
+
+If you were to look at: [Linkreplace](http://www.motoslave.net/sugarcube/2/docs/#macros-macro-linkreplace).
+You would see that it is pretty simple. It takes in `linkText` and then an optional `transition`/`t8n` (those two are equivalent).  
+Now, if you were to write:
+```html
+<<linkreplace>>Testing<</linkreplace>>
+```
+Well, this is obviously incorrect. We need to provide at least one argument. Sadly, our previous argument validation simply checks if the arguments are valid, not if they are valid arguments.  
+Then there is cases like:
+```html
+<<linkreplace [[Text->Passage]]>>Testing<</linkreplace>>
+```
+This doesn't make any sense, and would result in an unpleasant error (Note: as of v2.33.4 this simply appears as `[object Object]` due to it not being handled as an error!).  
+Then there is the case of too many arguments:
+```html
+<<linkreplace Alpha beta zeta>>Testing<</linkreplace>>
+```
+Where it is most certainly an error to do this, and it might be hard to notice! You likely meant to do:
+```html
+<<linkreplace "Alpha beta zeta">>Testing<</linkreplace>>
+```
+Then there is simple misspellings:
+```html
+<<linkreplace Alpha transiton>><</linkreplace>>
+```
+You might notice this if you're using a spell checker (There are extensions for that which work pretty well!), but then you might have gotten used to using `t8n` (the shorthand) and then accidentally wrote `tn8`, which your spellchecker likely won't catch.
+
+So, to resolve these cases:
+- Too few parameters
+- Invalid parameter types
+- Too many parameters
+- Misspellings of literal parameters
+- And more
+
+We have a way of specifying the types of the values a macro could receive, which is done - as usual - within the file which defines all of the macros that your project has:
+A field named `"parameters"` specifies all of the possible variants (which can be roughly thought of as overloads in some programming languages).  
+Here is how one might implement the `linkreplace` macro.
+```json
+"linkreplace": {
+    "name": "linkreplace",
+    "parameters": {
+        // The name of the variant and its format.
+        "primary": "text |+ 'transition'|'t8n'"
+    }
+}
+```
+Now, this likely looks a bit arcane.  
+The simplest part is the first element of the array: `"text"`, what is this?  
+This is a **parameter type**, which is one of many different types which specify what can be used as a parameter. These are used to validate the parameters given at that position within the macro's arguments. See the [Parameter Types](#parameter-types) section for more details on the exact types available.
+So, this can be any text. (or a variable/expression! See [Parameter Types Warning](#parameter-types-warning))  
+This, will make so doing:
+```html
+<<linkreplace [[Text->Passage]]>>
+```
+is now invalid! As well, it will make so the empty case, `<<linkreplace>>` is also invalid. We'll get warnings on both.  
+Now, we need to talk about the spooky `|+ 'transition'|'t8n'` syntax.  
+First, let's just look at: `'transition'`. These quotes around it mean it is a literal, in that we might literally type it, ex:
+```html
+<<linkreplace "Go Home" transition>>
+```
+**Note**: One could also use quotes here, `"transition"` becoming the same thing, the macro not caring whatsoever. A variable could also be used here. (See the [Parameter Types Warning](#parameter-types-warning)).  
+So, this lets us specify very specific parameters that are not generic parameter types.  
+Next, the `|`. This bar is called the 'or operator', and in `a|b` says "This argument is either *a* or it is *b*".  
+**Note**: It could be both as well! Either, because the left side and the right side are equivalent: `bool|bool` or they intersect `bool|false`.  
+The left side and the right side could be **parameter types** or **literals** (they can both be different as well!). So, in the case of `'transition'|'t8n'`, it is merely saying "This argument is either 'transition' or 't8n'".  
+**Note**: This is *chainable*. You can do `'transition'|'t8n'|'animate'|'fancy'|bool` and it will match any of those.  
+Next we have the.. weird `|+` syntax. You might have guessed this makes the value optional based on the documentation, but what is its exact meaning?  
+Well, this operator, `|+` is called "maybe-next". As you might have guessed, this makes so that the "next" argument is validated if it occurs, otherwise it doesn't have to appear. So, if there's a second parameter, then it must be `transition` or `t8n`.  
+See: [Operators](#operators) for a full list, descriptions and examples of the various operators.
+
+
+
+### Parameter Types
+There are a number of parameter types:
+- `bool`: A value that is either `true` or `false`.
+    - `true`: true literal value.
+    - `false`: false literal value.
+- `null`: A null literal value.
+- `undefined`: An undefined literal value.
+- `number`: A value that is some number. (`2`, `4.2`, `3.14159`, `-9.3`). We don't allow `NaN` in this position, since usually that is not intended to be allowed.
+- `NaN`: A literal `NaN`. Most often combined with `number`: `number|NaN`.
+- `link`: A link in the [Twine syntax](http://www.motoslave.net/sugarcube/2/docs/#markup-link): `[[Text->Passage]]`, `[[Passage]]`, `[[Text|Passage]]`, etc. Allows setter.
+    - `linkNoSetter`: A link that does not allow the setter syntax (`[[Passage][$wentToPassage = true]]`). Most notably required by the `<<link>>` macro.
+- `image`: An image in the [Twine syntax](http://www.motoslave.net/sugarcube/2/docs/#markup-image): `[img[Image]]`, `[img[Image][Passage]]`, etc.
+    - `imageNoSetter`: An image that does not allow the setter syntax (`[img[Image][Passage][$clickedImage = true]]`). Most notably required by the `<<link>>` macro.
+- `bareword`: A word that is on its own. Ex: `<<ex Alpha>>` (value: `Alpha`).
+- `string`: A quoted string. You may want to use `text` instead. Ex: ``
+- `text`: Arbitrary text, quoted or not. Includes much of the above (except for links/images). Ex: `<<ex test>>` (text: `test`), `<<ex "lorem ipsum">>` (text: `lorem ipsum`), `<<ex 24.9>>` (text: `24.9`).
+- `passage`: A passage name. (Note: Not currently verified to be valid).
+There are more proposed parameter types that may be implemented at a future data, if you have suggestions for useful types, please open an issue on the Github repository.
+
+#### Parameter Types Warning
+One should not rely on Parameter Types completely. All parameter types can be replaced with a: variable, access to settings, access to setup, or expression. Since the extension does not come with a supercomputer, it can not check if variables passed into macros will have sane values.  
+`<<link $value>>`. The extension *cannot* tell whether this is a `string`, a `link` object, a `number` or even a javascript function. Even simple cases, such as:
+```html
+<<set $value to "Go Home">>
+<<link $value>><</link>>
+```
+*Cannot* be checked for.
+
+### Operators
+#### Or `|`
+The `or` operator is the lone pipe `|` (it is distinct from the [Maybe-Next](#maybe-next) operator), and it simply means "This or that".  
+Example 1: `'a'|'b'`. Which simply means that the argument could be the literal `'a'` or the literal `'b'`. Anything else (remember the [Parameter Types Warning](#parameter-types-warning)!) is an error.  
+Example 2: `'death'|number` (for, perhaps a damage macro that takes HP or if it should be an instant kill). This is an example of using a literal or a parameter type.  
+Example 3: `'a'|'b'|'c'|'d'|'e'` You can chain the `or` operator repeatedly to make it `a` or `b` or `c` or `d` or `e`.  
+Example 4: `true|true`, `bool|true`. You can have values that intersect, if you wish, and it works just fine.  
+Example 5: This binds 'tighter' than other operators, meaning that `'a' &+ '1'|'2'|'3'` is interpreted as `'a' &+ ('1'|'2'|'3')`.
+#### And-Next `&+`
+The `and-next` operator is the ampersand with a plus, `&+`, which represents a requirement that the next argument exists for this part of the format to be valid.  
+Example 1: `'a' &+ 'b'` `a` must be followed by `b`. Ex: `<<ex a b>>`.  
+Example 2: It can be chained as usual, `'a' &+ 'b' &+ 'c'`. Ex: `<<ex a b c>>`  
+Example 3: Using it with a mix of parameter types and literals is completely allowed. `text &+ 'still'|'shake'|'shatter'`. Ex: `<<ex blah shake>>`, `<<ex "Testing This Macro" shatter>>`, etc.
+#### Maybe-Next `|+`
+The `maybe-next` operator is the pipe with a plus, `|+`, which represents a *next argument* that may or may not exist.  
+Example 1: `'a' |+ 'b'`. This would mean a literal `'a'` that could be (but doesn't have to be) followed by a `'b'`. (Ex: `<<ex a>>`, or `<<ex a b>>` are (roughly) allowed).  
+Example 2: `|+ 'b'`. It can be used to implement "empty or something" arguments. (Ex: `<<ex>>` or `<<ex b>>`)  
+Example 3: Ambiguity. You may run into ambiguous situations like: `'a' |+ 'b' &+ 'c'`. This is _not_ parsed left-to-right. the `and-next` operator binds 'harder' than `maybe-next`, and so it is equivalent to `'a' |+ ('b' &+ 'c')`. (ex: `a` or `a b c`) If you want it to be bound around the `maybe-next`, then do: `('a' |+ 'b') &+ 'c'` (ex: `a c` or `a b c`).
+#### Repeat
+The `repeat` operator is three periods, `...`, which is used for repeating elements zero or more times.  
+Due to limitations in parsing, this *must* only be a part of the last part.  
+Example 1: `...'a'`. Ex: `<<ex>>`, `<<ex a>>`, `<<ex a a a a a a a a a a a a>>`, etc.  
+Example 2: `...text`. Ex: `<<ex>>`, `<<ex Hello>>`, `<<ex Hello world, this is a test.>>`, etc.  
+Example 3: `...'a'|'b'`. The `repeat` operator binds looser than the `or` operator, so this is interpreted as `...('a'|'b')`. Ex: `<<ex>>`, `<<ex a>>`, `<<ex b>>`, `<<ex a a a b b a a a a a b>>`, etc.  
+Example 4: `text &+ ...text`. This is a common pattern which you would do if you want one or more entries. Ex: `<<ex Hello>>`, `<<ex Testing this macro.>>`, `<<ex "Blah blah blah." Testing.>>`  
+#### Grouping
+Grouping is done with parentheses, and is much like using parentheses in math or programming to group operators.  
+It can also be used for making things clearer and explicit if you don't entirely get the format string syntax.  
+Example 1: `('a')`. Equivalent to `'a'`.  
+Example 2: `('a'|'b')`. Equivalent to `'a'|'b'`.  
+Example 3: `('a' &+ 'b')`, `'a' &+ ('b')`, etc. I think you get the picture.  
+Example 4: `'a' (&+ 'b')` is valid, and is equivalent to the original.  
+Example 5: `'a' (&+) 'b'`. A syntax error.  
+Example 7: You may run into ambiguous situations like: `'a' |+ 'b' &+ 'c'` where you want `a` *or* `abc`. The given code would lead to `ac` *or* `abc`. Such a solution would be: `'a' |+ ('b' &+ 'c')`

--- a/package.json
+++ b/package.json
@@ -246,6 +246,11 @@
 					"type": "boolean",
 					"default": true,
 					"markdownDescription": "Provide errors about invalid argument syntax being passed into macros?"
+				},
+				"twee3LanguageTools.sugarcube-2.error.parameterValidation": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "Provide errors about invalid parameter types being passed into macros? Depends upon `argumentParsing`."
 				}
 			}
 		},

--- a/src/sugarcube-2/arguments.ts
+++ b/src/sugarcube-2/arguments.ts
@@ -406,6 +406,8 @@ export function parseArguments(document: vscode.TextDocument, macro: macro, macr
 				// characters.
 				// TODO: technically we could handle escaped characters (if that is all it does,
 				// but I am uncertain about that) manually.
+				// Remove quotation marks from string.
+				arg = arg.slice(1, -1);
 				args.arguments.push({
 					type: ArgType.String,
 					text: arg,

--- a/src/sugarcube-2/macros.json
+++ b/src/sugarcube-2/macros.json
@@ -25,7 +25,7 @@
 		"name": "script",
 		"container": true,
 		"description": "Silently executes its contents as *pure* JavaScript code—i.e., it performs no story or temporary variable substitution or TwineScript operator processing. For instances where you need to run some pure JavaScript and don't want to waste time performing extra processing on code that has no story or temporary variables or TwineScript operators in it and/or worry about the parser possibly clobbering the code.\n\nUsage:\n\n```\n<<script>> … <</script>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-script)",
-		"skipArgs": true
+		"parameters": {}
 	},
 
 	"=": {
@@ -40,13 +40,17 @@
 	},
 	"include": {
 		"name": "include",
-		"description": "Outputs the contents of the passage with the given name, optionally wrapping it within an HTML element. May be called either with the passage name or with a link markup.\n\nUsage:\n\n```\n<<include passageName [elementName]>>\n<<include linkMarkup [elementName]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-include)"
+		"description": "Outputs the contents of the passage with the given name, optionally wrapping it within an HTML element. May be called either with the passage name or with a link markup.\n\nUsage:\n\n```\n<<include passageName [elementName]>>\n<<include linkMarkup [elementName]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-include)",
+		"parameters": {
+			"passage": "passage |+ text",
+			"link": "linkNoSetter |+ text"
+		}
 	},
 	"nobr": {
 		"name": "nobr",
 		"container": true,
 		"description": "Executes its contents and outputs the result, after removing leading/trailing newlines and replacing all remaining sequences of newlines with single spaces.\n\nUsage:\n\n```\n<<nobr>> … <</nobr>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-nobr)",
-		"skipArgs": true
+		"parameters": {}
 	},
 	"print": {
 		"name": "print",
@@ -57,7 +61,7 @@
 		"name": "silently",
 		"container": true,
 		"description": "Causes any output generated within its body to be discarded, except for errors (which will be displayed). Generally, only really useful for formatting blocks of macros for ease of use/readability, while ensuring that no output is generated, from spacing or whatnot.\n\nUsage:\n\n```\n<<silently>> … <</silently>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-silently)",
-		"skipArgs": true
+		"parameters": {}
 	},
 	"type": {
 		"name": "type",
@@ -106,7 +110,7 @@
 			"for"
 		],
 		"description": "Used within `<<for>>` macros. Terminates the execution of the current `<<for>>`.\n\nUsage:\n\n```\n<<break>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-break)",
-		"skipArgs": true
+		"parameters": {}
 	},
 	"continue": {
 		"name": "continue",
@@ -114,7 +118,7 @@
 			"for"
 		],
 		"description": "Used within `<<for>>` macros. Terminates the execution of the current iteration of the current `<<for>>` and begins execution of the next iteration.\n\nUsage:\n\n```\n<<continue>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-continue)",
-		"skipArgs": true
+		"parameters": {}
 	},
 	"switch": {
 		"name": "switch",
@@ -145,11 +149,19 @@
 		"name": "button",
 		"container": true,
 		"description": "Creates a button that silently executes its contents when clicked, optionally forwarding the player to another passage. May be called either with the link text and passage name as separate arguments, with a link markup, or with an image markup.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<button linkText [passageName]>> … <</button>>\n<<button linkMarkup>> … <</button>>\n<<button imageMarkup>> … <</button>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-button)",
-		"selfClose": true
+		"selfClose": true,
+		"parameters": {
+			"separate": "text |+ passage",
+			"link": "linkNoSetter",
+			"image": "imageNoSetter"
+		}
 	},
 	"checkbox": {
 		"name": "checkbox",
-		"description": "Creates a checkbox, used to modify the value of the variable with the given name.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<checkbox receiverName uncheckedValue checkedValue [autocheck|checked]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-checkbox)"
+		"description": "Creates a checkbox, used to modify the value of the variable with the given name.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<checkbox receiverName uncheckedValue checkedValue [autocheck|checked]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-checkbox)",
+		"parameters": {
+			"checkbox": "text &+ bool|text|null|undefined|number|NaN &+ bool|text|null|undefined|number|NaN |+ 'autocheck'|'checked'"
+		}
 	},
 	"cycle": {
 		"name": "cycle",
@@ -158,14 +170,20 @@
 			"optionsfrom"
 		],
 		"container": true,
-		"description": "Creates a cycling link, used to modify the value of the variable with the given name. The cycling options are populated via `<<option>>` and/or `<<optionsfrom>>`.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<cycle receiverName [autoselect]>>\n\t[<<option label [value [selected]]>> …]\n\t[<<optionsfrom collection>> …]\n<</cycle>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-cycle)"
+		"description": "Creates a cycling link, used to modify the value of the variable with the given name. The cycling options are populated via `<<option>>` and/or `<<optionsfrom>>`.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<cycle receiverName [autoselect]>>\n\t[<<option label [value [selected]]>> …]\n\t[<<optionsfrom collection>> …]\n<</cycle>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-cycle)",
+		"parameters": {
+			"cycle": "text |+ 'autoselect'"
+		}
 	},
 	"option": {
 		"name": "option",
 		"parents": [
 			"cycle",
 			"listbox"
-		]
+		],
+		"parameters": {
+			"option": "text |+ (text |+ 'selected')"
+		}
 	},
 	"optionsfrom": {
 		"name": "optionsfrom",
@@ -179,22 +197,36 @@
 		"name": "link",
 		"container": true,
 		"description": "Creates a link that silently executes its contents when clicked, optionally forwarding the player to another passage. May be called either with the link text and passage name as separate arguments, with a link markup, or with an image markup.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<link linkText [passageName]>> … <</link>>\n<<link linkMarkup>> … <</link>>\n<<link imageMarkup>> … <</link>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-link)",
-		"selfClose": true
+		"selfClose": true,
+		"parameters": {
+			"separate": "text |+ passage",
+			"link": "linkNoSetter",
+			"image": "imageNoSetter"
+		}
 	},
 	"linkappend": {
 		"name": "linkappend",
 		"container": true,
-		"description": "Creates a single-use link that deactivates itself and appends its contents to its link text when clicked. Essentially, a combination of `<<link>>` and `<<append>>`.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<linkappend linkText [transition|t8n]>> … <</linkappend>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-linkappend)"
+		"description": "Creates a single-use link that deactivates itself and appends its contents to its link text when clicked. Essentially, a combination of `<<link>>` and `<<append>>`.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<linkappend linkText [transition|t8n]>> … <</linkappend>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-linkappend)",
+		"parameters": {
+			"linkappend": "text |+ 'transition'|'t8n'"
+		}
 	},
 	"linkprepend": {
 		"name": "linkprepend",
 		"container": true,
-		"description": "Creates a single-use link that deactivates itself and prepends its contents to its link text when clicked. Essentially, a combination of `<<link>>` and `<<prepend>>`.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<linkprepend linkText [transition|t8n]>> … <</linkprepend>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-linkprepend)"
+		"description": "Creates a single-use link that deactivates itself and prepends its contents to its link text when clicked. Essentially, a combination of `<<link>>` and `<<prepend>>`.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<linkprepend linkText [transition|t8n]>> … <</linkprepend>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-linkprepend)",
+		"parameters": {
+			"linkprepend": "text |+ 'transition'|'t8n'"
+		}
 	},
 	"linkreplace": {
 		"name": "linkreplace",
 		"container": true,
-		"description": "Creates a single-use link that deactivates itself and replaces its link text with its contents when clicked. Essentially, a combination of `<<link>>` and `<<replace>>`.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<linkreplace linkText [transition|t8n]>> … <</linkreplace>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-linkreplace)"
+		"description": "Creates a single-use link that deactivates itself and replaces its link text with its contents when clicked. Essentially, a combination of `<<link>>` and `<<replace>>`.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<linkreplace linkText [transition|t8n]>> … <</linkreplace>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-linkreplace)",
+		"parameters": {
+			"linkreplace": "text |+ 'transition'|'t8n'"
+		}
 	},
 	"listbox": {
 		"name": "listbox",
@@ -203,76 +235,135 @@
 			"optionsfrom"
 		],
 		"container": true,
-		"description": "Creates a listbox, used to modify the value of the variable with the given name. The list options are populated via `<<option>>` and/or `<<optionsfrom>>`.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<listbox receiverName [autoselect]>>\n\t[<<option label [value [selected]]>> …]\n\t[<<optionsfrom collection>> …]\n<</listbox>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-listbox)"
+		"description": "Creates a listbox, used to modify the value of the variable with the given name. The list options are populated via `<<option>>` and/or `<<optionsfrom>>`.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<listbox receiverName [autoselect]>>\n\t[<<option label [value [selected]]>> …]\n\t[<<optionsfrom collection>> …]\n<</listbox>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-listbox)",
+		"parameters": {
+			"listbox": "text |+ 'autoselect'"
+		}
 	},
 	"numberbox": {
 		"name": "numberbox",
-		"description": "Creates a number input box, used to modify the value of the variable with the given name, optionally forwarding the player to another passage.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<numberbox receiverName defaultValue [passage] [autofocus]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-numberbox)"
+		"description": "Creates a number input box, used to modify the value of the variable with the given name, optionally forwarding the player to another passage.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<numberbox receiverName defaultValue [passage] [autofocus]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-numberbox)",
+		"parameters": {
+			"numberbox": "text &+ number |+ passage |+ 'autofocus'"
+		}
 	},
 	"radiobutton": {
 		"name": "radiobutton",
-		"description": "Creates a radio button, used to modify the value of the variable with the given name. Multiple `<<radiobutton>>` macros may be set up to modify the same variable, which makes them part of a radio button group.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<radiobutton receiverName checkedValue [autocheck|checked]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-radiobutton)"
+		"description": "Creates a radio button, used to modify the value of the variable with the given name. Multiple `<<radiobutton>>` macros may be set up to modify the same variable, which makes them part of a radio button group.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<radiobutton receiverName checkedValue [autocheck|checked]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-radiobutton)",
+		"parameters": {
+			"radiobutton": "text &+ bool|number|text|null|undefined|NaN |+ 'autocheck'|'checked'"
+		}
 	},
 	"textarea": {
 		"name": "textarea",
-		"description": "Creates a multiline text input block, used to modify the value of the variable with the given name.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<textarea receiverName defaultValue [autofocus]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-textarea)"
+		"description": "Creates a multiline text input block, used to modify the value of the variable with the given name.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<textarea receiverName defaultValue [autofocus]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-textarea)",
+		"parameters": {
+			"textarea": "text &+ text |+ 'autofocus'"
+		}
 	},
 	"textbox": {
 		"name": "textbox",
-		"description": "Creates a text input box, used to modify the value of the variable with the given name, optionally forwarding the player to another passage.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<textbox receiverName defaultValue [passage] [autofocus]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-textbox)"
+		"description": "Creates a text input box, used to modify the value of the variable with the given name, optionally forwarding the player to another passage.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<textbox receiverName defaultValue [passage] [autofocus]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-textbox)",
+		"parameters": {
+			"textbox": "text &+ text |+ passage |+ 'autofocus'"
+		}
 	},
 	
 	"actions": {
 		"name": "actions",
-		"description": "Creates a list of single-use passage links. Each link removes itself and all other `<<actions>>` links to the same passage after being activated. May be called either with a list of passages, with a list of link markup, or with a list of image markup. Probably most useful when paired with `<<include>>`.\n\nUsage:\n\n```\n<<actions passageList>>\n<<actions linkMarkupList>>\n<<actions imageMarkupList>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-actions)"
+		"description": "Creates a list of single-use passage links. Each link removes itself and all other `<<actions>>` links to the same passage after being activated. May be called either with a list of passages, with a list of link markup, or with a list of image markup. Probably most useful when paired with `<<include>>`.\n\nUsage:\n\n```\n<<actions passageList>>\n<<actions linkMarkupList>>\n<<actions imageMarkupList>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-actions)",
+		"parameters": {
+			"passage": "passage &+ ...passage",
+			"link": "link &+ ...link",
+			"image": "image &+ ...image"
+		}
 	},
 	"back": {
 		"name": "back",
-		"description": "Creates a link that undoes past moments within the story history. May be called with, optional, link text or with a link or image markup.\n\nUsage:\n\n```\n<<back [linkText]>>\n<<back linkMarkup>>\n<<back imageMarkup>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-back)"
+		"description": "Creates a link that undoes past moments within the story history. May be called with, optional, link text or with a link or image markup.\n\nUsage:\n\n```\n<<back [linkText]>>\n<<back linkMarkup>>\n<<back imageMarkup>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-back)",
+		"parameters": {
+			"text": "|+ text",
+			"link": "linkNoSetter",
+			"image": "imageNoSetter"
+		}
 	},
 	"choice": {
 		"name": "choice",
-		"description": "Creates a single-use passage link that deactivates itself and all other `<<choice>>` links within the originating passage when activated. May be called either with the passage name and link text as separate arguments, with a link markup, or with a image markup.\n\nUsage:\n\n```\n<<choice passageName [linkText]>>\n<<choice linkMarkup>>\n<<choice imageMarkup>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-choice)"
+		"description": "Creates a single-use passage link that deactivates itself and all other `<<choice>>` links within the originating passage when activated. May be called either with the passage name and link text as separate arguments, with a link markup, or with a image markup.\n\nUsage:\n\n```\n<<choice passageName [linkText]>>\n<<choice linkMarkup>>\n<<choice imageMarkup>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-choice)",
+		"parameters": {
+			"separate": "passage |+ text",
+			"link": "link",
+			"image": "image"
+		}
 	},
 	"return": {
 		"name": "return",
-		"description": "Creates a link that navigates forward to a previously visited passage. May be called with, optional, link text or with a link or image markup.\n\nUsage:\n\n```\n<<return [linkText]>>\n<<return linkMarkup>>\n<<return imageMarkup>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-return)"
+		"description": "Creates a link that navigates forward to a previously visited passage. May be called with, optional, link text or with a link or image markup.\n\nUsage:\n\n```\n<<return [linkText]>>\n<<return linkMarkup>>\n<<return imageMarkup>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-return)",
+		"parameters": {
+			"text": "|+ text",
+			"link": "linkNoSetter",
+			"image": "imageNoSetter"
+		}
 	},
 	
 	"addclass": {
 		"name": "addclass",
-		"description": "Adds classes to the selected element(s).\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<addclass selector classNames>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-addclass)"
+		"description": "Adds classes to the selected element(s).\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<addclass selector classNames>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-addclass)",
+		"parameters": {
+			"addclass": "text |+ text"
+		}
 	},
 	"append": {
 		"name": "append",
 		"container": true,
-		"description": "Executes its contents and appends the output to the contents of the selected element(s).\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<append selector [transition|t8n]>> … <</append>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-append)"
+		"description": "Executes its contents and appends the output to the contents of the selected element(s).\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<append selector [transition|t8n]>> … <</append>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-append)",
+		"parameters": {
+			"append": "text |+ 'transition'|'t8n'"
+		}
 	},
 	"copy": {
 		"name": "copy",
-		"description": "Outputs a copy of the contents of the selected element(s).\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<copy selector>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-copy)"
+		"description": "Outputs a copy of the contents of the selected element(s).\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<copy selector>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-copy)",
+		"parameters": {
+			"copy": "text"
+		}
 	},
 	"prepend": {
 		"name": "prepend",
 		"container": true,
-		"description": "Executes its contents and prepends the output to the contents of the selected element(s).\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<prepend selector [transition|t8n]>> … <</prepend>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-prepend)"
+		"description": "Executes its contents and prepends the output to the contents of the selected element(s).\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<prepend selector [transition|t8n]>> … <</prepend>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-prepend)",
+		"parameters": {
+			"prepend": "text |+ 'transition'|'t8n'"
+		}
 	},
 	"remove": {
 		"name": "remove",
-		"description": "Removes the selected element(s).\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<remove selector>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-remove)"
+		"description": "Removes the selected element(s).\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<remove selector>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-remove)",
+		"parameters": {
+			"remove": "text"
+		}
 	},
 	"removeclass": {
 		"name": "removeclass",
-		"description": "Removes classes from the selected element(s).\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<removeclass selector [classNames]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-removeclass)"
+		"description": "Removes classes from the selected element(s).\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<removeclass selector [classNames]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-removeclass)",
+		"parameters": {
+			"removeclass": "text |+ text"
+		}
 	},
 	"replace": {
 		"name": "replace",
 		"container": true,
-		"description": "Executes its contents and replaces the contents of the selected element(s) with the output.\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<replace selector [transition|t8n]>> … <</replace>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-replace)"
+		"description": "Executes its contents and replaces the contents of the selected element(s) with the output.\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<replace selector [transition|t8n]>> … <</replace>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-replace)",
+		"parameters": {
+			"replace": "text |+ 'transition'|'t8n'"
+		}
 	},
 	"toggleclass": {
 		"name": "toggleclass",
-		"description": "Toggles classes on the selected element(s)—i.e., adding them if they don't exist, removing them if they do.\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<toggleclass selector classNames>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-toggleclass)"
+		"description": "Toggles classes on the selected element(s)—i.e., adding them if they don't exist, removing them if they do.\n\nSEE: [DOM macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-dom-warning)\n\nUsage:\n\n```\n<<toggleclass selector classNames>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-toggleclass)",
+		"parameters": {
+			"toggleclass": "text |+ text"
+		}
 	},
 	
 	"audio": {
@@ -281,7 +372,10 @@
 	},
 	"cacheaudio": {
 		"name": "cacheaudio",
-		"description": "Caches an audio track for use by the other audio macros.\n\nUsage:\n\n```\n<<cacheaudio trackId sourceList>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-cacheaudio)"
+		"description": "Caches an audio track for use by the other audio macros.\n\nUsage:\n\n```\n<<cacheaudio trackId sourceList>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-cacheaudio)",
+		"parameters": {
+			"cacheaudio": "text &+ text &+ ...text"
+		}
 	},
 	"createaudiogroup": {
 		"name": "createaudiogroup",
@@ -289,7 +383,10 @@
 			"track"
 		],
 		"container": true,
-		"description": "Collects tracks, which must be set up via `<<cacheaudio>>`, into a group via its `<<track>>` children. Groups are useful for applying actions to multiple tracks simultaneously and/or excluding the included tracks from a larger set when applying actions.\n\nUsage:\n\n```\n<<createaudiogroup groupId>>\n\t[<<track trackId>> …]\n<</createaudiogroup>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-createaudiogroup)"
+		"description": "Collects tracks, which must be set up via `<<cacheaudio>>`, into a group via its `<<track>>` children. Groups are useful for applying actions to multiple tracks simultaneously and/or excluding the included tracks from a larger set when applying actions.\n\nUsage:\n\n```\n<<createaudiogroup groupId>>\n\t[<<track trackId>> …]\n<</createaudiogroup>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-createaudiogroup)",
+		"parameters": {
+			"createaudiogroup": "text"
+		}
 	},
 	"track": {
 		"name": "track",
@@ -304,7 +401,10 @@
 			"track"
 		],
 		"container": true,
-		"description": "Collects tracks, which must be set up via `<<cacheaudio>>`, into a playlist via its `<<track>>` children.\n\nUsage:\n\n```\n<<createplaylist listId>>\n\t[<<track trackId actionList>> …]\n<</createplaylist>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-createplaylist)"
+		"description": "Collects tracks, which must be set up via `<<cacheaudio>>`, into a playlist via its `<<track>>` children.\n\nUsage:\n\n```\n<<createplaylist listId>>\n\t[<<track trackId actionList>> …]\n<</createplaylist>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-createplaylist)",
+		"parameters": {
+			"createplaylist": "text"
+		}
 	},
 	"playlist": {
 		"name": "playlist",
@@ -316,22 +416,33 @@
 	},
 	"removeaudiogroup": {
 		"name": "removeaudiogroup",
-		"description": "Removes the audio group with the given ID.\n\nUsage:\n\n```\n<<removeaudiogroup groupId>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-masteraudio)"
+		"description": "Removes the audio group with the given ID.\n\nUsage:\n\n```\n<<removeaudiogroup groupId>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-masteraudio)",
+		"parameters": {
+			"removeaudiogroup": "text"
+		}
 	},
 	"removeplaylist": {
 		"name": "removeplaylist",
-		"description": "Removes the playlist with the given ID.\n\nUsage:\n\n```\n<<removeplaylist listId>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-removeplaylist)"
+		"description": "Removes the playlist with the given ID.\n\nUsage:\n\n```\n<<removeplaylist listId>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-removeplaylist)",
+		"parameters": {
+			"removeplaylist": "text"
+		}
 	},
 	"waitforaudio": {
 		"name": "waitforaudio",
 		"description": "Displays the loading screen until all currently registered audio has either loaded to a playable state or aborted loading due to errors. Requires tracks to be set up via `<<cacheaudio>>`.\n\nUsage:\n\n```\n<<waitforaudio>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-waitforaudio)",
-		"skipArgs": true
+		"skipArgs": true,
+		"parameters": {}
 	},
 
 
 	"goto": {
 		"name": "goto",
-		"description": "Immediately forwards the player to the passage with the given name. May be called either with the passage name or with a link markup.\n\nUsage:\n\n```\n<<goto passageName>>\n<<goto linkMarkup>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-goto)"
+		"description": "Immediately forwards the player to the passage with the given name. May be called either with the passage name or with a link markup.\n\nUsage:\n\n```\n<<goto passageName>>\n<<goto linkMarkup>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-goto)",
+		"parameters": {
+			"passage": "passage",
+			"goto": "linkNoSetter"
+		}
 	},
 	"repeat": {
 		"name": "repeat",
@@ -339,14 +450,18 @@
 			"stop"
 		],
 		"container": true,
-		"description": "Repeatedly executes its contents after the given delay, inserting any output into the passage in its place. May be terminated by a `<<stop>>` macro.\n\nUsage:\n\n```\n<<repeat delay [transition|t8n]>> … <</repeat>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-repeat)"
+		"description": "Repeatedly executes its contents after the given delay, inserting any output into the passage in its place. May be terminated by a `<<stop>>` macro.\n\nUsage:\n\n```\n<<repeat delay [transition|t8n]>> … <</repeat>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-repeat)",
+		"parameters": {
+			"repeat": "text |+ 'transition'|'t8n'"
+		}
 	},
 	"stop": {
 		"name": "stop",
 		"parents": [
 			"repeat"
 		],
-		"description": "Used within `<<repeat>>` macros. Terminates the execution of the current `<<repeat>>`.\n\nUsage:\n\n```\n<<stop>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-stop)"
+		"description": "Used within `<<repeat>>` macros. Terminates the execution of the current `<<repeat>>`.\n\nUsage:\n\n```\n<<stop>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-stop)",
+		"parameters": {}
 	},
 	"timed": {
 		"name": "timed",
@@ -354,18 +469,27 @@
 			"next"
 		],
 		"container": true,
-		"description": "Executes its contents after the given delay, inserting any output into the passage in its place. Additional timed executions may be chained via `<<next>>`.\n\nUsage:\n\n```\n<<timed delay [transition|t8n]>> …\n\t[<<next [delay]>> …]\n<</timed>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-timed)"
+		"description": "Executes its contents after the given delay, inserting any output into the passage in its place. Additional timed executions may be chained via `<<next>>`.\n\nUsage:\n\n```\n<<timed delay [transition|t8n]>> …\n\t[<<next [delay]>> …]\n<</timed>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-timed)",
+		"parameters": {
+			"timed": "text |+ 'transition'|'t8n'"
+		}
 	},
 	"next": {
 		"name": "next",
 		"parents": [
 			"timed"
-		]
+		],
+		"parameters": {
+			"next": "|+ text"
+		}
 	},
 	"widget": {
 		"name": "widget",
 		"container": true,
-		"description": "Creates a new widget macro (henceforth, widget) with the given name. Widgets allow you to create macros by using the standard macros and markup that you use normally within your story. Widgets may access arguments passed to them via the `$args` array-like object—see below for details.\n\nUsage:\n\n```\n<<widget widgetName>> … <</widget>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-widget)"
+		"description": "Creates a new widget macro (henceforth, widget) with the given name. Widgets allow you to create macros by using the standard macros and markup that you use normally within your story. Widgets may access arguments passed to them via the `$args` array-like object—see below for details.\n\nUsage:\n\n```\n<<widget widgetName>> … <</widget>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-widget)",
+		"parameters": {
+			"widget": "text"
+		}
 	},
 	
 	"click": {
@@ -375,14 +499,23 @@
 		"deprecated": true,
 		"deprecatedSuggestions": [
 			"macro: <<link>>"
-		]
+		],
+		"parameters": {
+			"text": "text |+ passage",
+			"link": "linkNoSetter",
+			"image": "imageNoSetter"
+		}
 	},
 	"display": {
 		"name": "display",
 		"deprecated": true,
 		"deprecatedSuggestions": [
 			"macro: <<include>>"
-		]
+		],
+		"parameters": {
+			"passage": "passage |+ text",
+			"link":"linkNoSetter |+ text"
+		}
 	},
 	"forget": {
 		"name": "forget",
@@ -414,6 +547,6 @@
 		"deprecatedSuggestions": [
 			"macro: <<audio>> (<<audio ':all' stop>>)"
 		],
-		"skipArgs": true
+		"parameters": {}
 	}
 }

--- a/src/sugarcube-2/parameters.ts
+++ b/src/sugarcube-2/parameters.ts
@@ -1,0 +1,1129 @@
+import * as vscode from 'vscode';
+import { Arg, ArgType, ExpressionArgument, ParsedArguments, SettingsSetupAccessArgument, VariableArgument } from './arguments';
+
+export type UnparsedFormat = string;
+// Note: This may eventually also be allowed to become an object, for more configuration options.
+export type UnparsedVariant = UnparsedFormat;
+
+// The warning class is for things that are technically 'errors' (in that they are invalid)
+// but are likely just slightly incorrect and so should be counted as at least a partial validity
+// for a given variant. (Ex: Passing a link with a setter to something that takes `linkNoSetter`)
+export class Warning {
+    readonly message: string;
+
+    constructor(message: string) {
+        this.message = message;
+    }
+}
+
+/**
+ * Helper function for constructing simple paramter types without the boilerplate
+ */
+function makeSimpleParameterType(name: string | string[], errorMessage: string, validateType: ((type: ArgType) => boolean) | ArgType) {
+    if (typeof(name) === 'string') {
+        name = [name];
+    }
+
+    if (typeof(validateType) === 'number') {
+        // Store enum in separate variable
+        const validateTypeCopy = validateType;
+        // Create a closure for consistency
+        validateType = type => type === validateTypeCopy;
+    }
+
+    // Hack to make typescript recognize that this has to be a function now.
+    const validateTypeCallback = validateType as (type: ArgType) => boolean;
+    return {
+        name,
+        validate (info: ArgumentInfo): Error | null {
+            if (validateTypeCallback(info.arg.type)) {
+                // Success.
+                return null;
+            } else {
+                return new Error(errorMessage);
+            }
+        }
+    };
+}
+
+/**
+ * Parameter types.
+ * These don't need to check for things that are already checked by the `isAlwaysArgument`.
+ * Naming should be camelCase.
+ * Type names are currently case-sensitive.
+ */
+const parameterTypes: ParameterType[] = [
+    makeSimpleParameterType("true", "Argument is not 'true'", ArgType.True),
+    makeSimpleParameterType("false", "Argument is not 'false'", ArgType.False),
+    makeSimpleParameterType(["bool", "boolean"], "Argument is not a boolean", type => type === ArgType.True || type === ArgType.False),
+    makeSimpleParameterType("null", "Argument is not 'null'", ArgType.Null),
+    makeSimpleParameterType("undefined", "Argument is not 'undefined'", ArgType.Undefined),
+    makeSimpleParameterType("number", "Argument is not a number", ArgType.Number),
+    makeSimpleParameterType("NaN", "Argument is not 'NaN'", ArgType.NaN),
+    makeSimpleParameterType("link", "Argument is not a link", ArgType.Link),
+    makeSimpleParameterType("image", "Argument is not an image", ArgType.Image),
+    makeSimpleParameterType("bareword", "Argument is not a bareword", ArgType.Bareword),
+    makeSimpleParameterType("string", "Argument is not a quoted string", ArgType.String),
+    // This allows so many because they could all be turned-into/considered text.
+    makeSimpleParameterType("text", "Argument is not text", t => t === ArgType.Bareword || t === ArgType.String || t === ArgType.True || t === ArgType.False || t === ArgType.Null || t === ArgType.NaN || t === ArgType.Number),
+    {
+        name: ["linkNoSetter"],
+        validate(info: ArgumentInfo): Error | Warning | null {
+            if (info.arg.type !== ArgType.Link) {
+                return new Error("Argument is not a link");
+            }
+
+            if (info.arg.setter) {
+                return new Warning("Argument is a link, but does not allow setter syntax");
+            }
+
+            // Success
+            return null;
+        }
+    },
+    {
+        name: ["imageNoSetter"],
+        validate(info: ArgumentInfo): Error | Warning | null {
+            if (info.arg.type !== ArgType.Image) {
+                return new Error("Argument is not an image");
+            }
+
+            if (info.arg.setter) {
+                return new Warning("Argument is an image, but does not allow setter syntax");
+            }
+
+            // Success
+            return null;
+        }
+    },
+    {
+        name: ["passage"],
+        validate(info: ArgumentInfo): Error | null {
+            // TODO; Validate the passage name (if possible)
+            let t = info.arg.type;
+            if (t === ArgType.Bareword || t === ArgType.String || t === ArgType.True || t === ArgType.False || t === ArgType.Null || t === ArgType.NaN || t === ArgType.Number) {
+                return null;
+            } else {
+                return new Error("Argument is not an acceptable passage");
+            }
+        }
+    }
+];
+function findParameterType(name: string): null | ParameterType {
+    for (let i = 0; i < parameterTypes.length; i++) {
+        if (parameterTypes[i].name.includes(name)) {
+            return parameterTypes[i];
+        }
+    }
+    return null;
+}
+interface ParameterType {
+    /**
+     * Names that this parameter goes by.
+     */
+    name: string[],
+    /**
+     * Checks if the parameter is valid here.
+     * Returns `null` if there was no errors
+     * otherwise returns an Error instance.
+     */
+    validate: (info: ArgumentInfo) => Error | Warning | null;
+}
+
+/**
+ * Information about the arguments that are being parsed.
+ */
+interface ArgumentInfo {
+    arguments: Arg[],
+    // Index into `arguments` that our current argument is at.
+    index: number,
+    // Easy access. Equivalent to `arguments[index]`.
+    arg: Arg,
+}
+
+/**
+ * TODO: use UnparsedMacro definition.
+ * @param list The list of macros. Modified in-place.
+ * @returns {Error[]} A potentially empty list of errors that occurred.
+ */
+export function parseMacroParameters(list: Record<string, Record<string, any>>): Error[] {
+    let errors: Error[] = [];
+    for (let key in list) {
+        let macroDefinition = list[key];
+        if (macroDefinition.parameters === undefined) {
+            continue;
+        }
+
+        if (macroDefinition.parameters === null || typeof (macroDefinition.parameters) !== 'object' || Array.isArray(macroDefinition.parameters)) {
+            errors.push(new Error(`Error while checking parameters of '${macroDefinition.name}': The parameters were not a valid object.`));
+            delete macroDefinition.parameters;
+            continue;
+        } else if (macroDefinition.parameters instanceof Parameters) {
+            // Ignore parameters that have already been parsed.
+            continue;
+        }
+
+        try {
+            // Overwrite the previous parameters with the parsed version
+            macroDefinition.parameters = new Parameters(macroDefinition.parameters);
+        } catch (err) {
+            errors.push(new Error(`Error while parsing parameters of '${macroDefinition.name}': ${err.message || "Failed to get error message, please report this."}`));
+        }
+    }
+    return errors;
+}
+
+export interface ChosenVariantInformation {
+    // The key of the chosen variant.
+    // null if no variant was chosen
+    variantKey: string | null,
+    info: ValidateInformation,
+}
+export class Parameters {
+    variants: Record<string, Variant>;
+
+    /**
+     * Construct a new Parameters instance from the unvalidated json.
+     * @param variants The variants/'overloads' of the macro's parameters.
+     * @throws {Error}
+     */
+    constructor(variants: { [key: string]: any }) {
+        let result: Record<string, Variant> = {};
+        for (let key in variants) {
+            if (variants[key] === null || variants[key] === undefined) {
+                throw new Error(`Undefined/null variants are not allowed (variant: ${key}).`);
+            } else if (typeof (variants[key]) === "string") {
+                if (result.hasOwnProperty(key)) {
+                    // We already have the key, which is strange.
+                    // This probably isn't a duplicate key, but one like `__proto__`.
+                    throw new Error(`Duplicate or unsupported variant name ${key}`);
+                }
+                result[key] = new Variant(variants[key]);
+                // Note: Later we could add support for objects to make so that variants could have
+                // configuration options
+            } else {
+                throw new Error(`Invalid value, currently only string variants allowed. (variant: ${key})`);
+            }
+        }
+        this.variants = result;
+    }
+
+    /**
+     * Checks the given arguments for their matching to a chosen
+     * @param args The parsed arguments for type validation
+     */
+    validate(args: ParsedArguments): ChosenVariantInformation {
+        // We track the current most likely variant based on type and somewhat on
+        // argument count. This certainly isn't the most accurate implementation but it
+        // should work well enough for now.
+        let highestVariant: ChosenVariantInformation = {
+            variantKey: null,
+            info: {
+                errors: [],
+                warnings: [],
+                rank: -1,
+                argIndex: 0
+            }
+        };
+
+        // TODO: Add rank based on correct argument count?
+
+        for (const variantKey in this.variants) {
+            const variant = this.variants[variantKey];
+            let info = variant.validate(args);
+
+            if (info.rank > highestVariant.info.rank) {
+                highestVariant.info = info;
+                highestVariant.variantKey = variantKey;
+            }
+        }
+
+        return highestVariant;
+    }
+
+    /**
+     * Whether the variants are empty.
+     */
+    isEmpty(): boolean {
+        for (let key in this.variants) {
+            if (!this.variants[key].isEmpty()) {
+                // We found a non-empty entry.
+                return false;
+            }
+        }
+        return true;
+    }
+}
+/**
+ * Information about the result of validating a variant.
+ */
+export interface ValidateInformation {
+    warnings: ArgumentWarning[],
+    errors: ArgumentError[],
+    // The ranking that it received.
+    // A 'minimum' goal of the rank is to at always (or at least try) to get the highest rank
+    // for a variant if it exactly matches the argument types without errors.
+    rank: number,
+    // The index that was reached into the arguments.
+    argIndex: number,
+}
+/**
+ * An error for a specific argument.
+ */
+export interface ArgumentError {
+    error: Error,
+    // Index into arguments
+    index: number,
+}
+/**
+ * A warning for a specific argument.
+ */
+export interface ArgumentWarning {
+    warning: Warning,
+    // Index into arguments
+    index: number,
+}
+export class Variant {
+    formatString: UnparsedFormat;
+    format: Format | null;
+
+    /**
+     * Constructs a new variant, parsing the given format string into an easier form.
+     * @param formatString The format string to be parsed.
+     * @throws {Error}
+     */
+    constructor(formatString: UnparsedFormat) {
+        this.formatString = formatString;
+        this.format = Variant.parseFormat(formatString);
+    }
+
+    /**
+     * Whether or not the variant is empty.
+     */
+    isEmpty(): boolean {
+        return this.format === null;
+    }
+
+    /**
+     * Limitation on how many times the validation can iterate before stopping.
+     * TODO: Configurable in settings. Perhaps configurable per macro for really expensive macros.
+     */
+    private static ValidateLimit: number = 2000;
+    /**
+     * Checks if the arguments are valid based on this variant.
+     */
+    validate(parsedArguments: ParsedArguments): ValidateInformation {
+        // Shorthand
+        const args = parsedArguments.arguments;
+        let iterations: number = 0;
+
+        enum Status {
+            NotFoundFailure,
+            Failure,
+            Success,
+        }
+        function isFailure (status: Status): status is (Status.Failure | Status.NotFoundFailure){
+            return status === Status.Failure || status == Status.NotFoundFailure;
+        }
+
+        interface CrawlInformation extends ValidateInformation {
+            status: Status,
+        }
+        /**
+         * Construct an error CrawlInformation.
+         * Note: This assumes that the given argIndex is the place where the error happened!
+         * Pure.
+         */
+        function makeError(status: Status, text: string, argIndex: number, rank: number = 0): CrawlInformation {
+            return {
+                errors: [{
+                    error: new Error(text),
+                    index: argIndex,
+                }],
+                warnings: [],
+                rank,
+                argIndex,
+                status,
+            };
+        }
+        /**
+         * Construct a simple success CrawlInformation.
+         * Pure.
+         */
+        function makeSuccess(argIndex: number, rank: number, warnings: ArgumentWarning[] = []): CrawlInformation {
+            return {
+                errors: [],
+                warnings,
+                rank,
+                argIndex,
+                status: Status.Success,
+            }
+        }
+
+        // The type was correct
+        const correctTypeRank: number = 1;
+        // The type and value were correct
+        const correctRank: number = correctTypeRank + 1;
+
+        // This isn't the most efficient it could be.
+        // 1: We could transform repeated instances of certain operators into list versions
+        // which would be easier to check and deal with, and probably faster due to less recursion
+        // and passing around objects of information. `Or` is the most obvious recipient of this.
+        // 2: We construct a lot of errors that aren't used. This could be delayed using
+        // closures in many of the cases, which I presume are faster to construct than performing
+        // string formatting.
+        // As well there are some reasoning problems within that could be improved:
+        // 1: Ranks. In some cases this makes sense to keep.
+        //  If you're parsing a maybenext, then should it keep the rank from the right side even if
+        //  it failed? The immediate answer is no, but shouldn't it factor into how it chooses the 
+        //  correct variant? This could be done through two methods:
+        //      1: Messing with the rank. If the optional part of the maybenext failed then it gets
+        //         mathematically messed with. Perhaps divided by 2 then added. This has the problem
+        //         of being iffy and making it even harder to reason about how it chooses a good
+        //         variant.
+        //      2: New property. Perhaps globalRank that gets added despite errors, used for
+        //         complete type matches on arguments?
+        /**
+         * Crawl the tree.
+         * This shouldn't run have issues with stack overflow bcs the limited complexity of macros
+         * @param format The format we are on
+         * @param argIndex The index into the arguments that this branch of crawl is using.
+         */
+        function crawl(format: Format, argIndex: number): CrawlInformation {
+            iterations++;
+            if (iterations >= Variant.ValidateLimit) {
+                throw new Error(`Validating macro took excessive amount of checking. Quitting. Got to argument ${argIndex}.`);
+            }
+
+            if (format.kind === FormatKind.MaybeNext) {
+                let rank: number = 0;
+                let warnings: ArgumentWarning[] = [];
+                // If we have a left, then that has to exist before the right can be thought about
+                if (format.left) {
+                    const infoLeft = crawl(format.left, argIndex);
+                    rank += infoLeft.rank;
+                    argIndex = infoLeft.argIndex;
+                    // If the status is NotFoundFailure or Failure then we have failed.
+                    if (isFailure(infoLeft.status)) {
+                        // Return info since we failed and the left hand side is required.
+                        return infoLeft;
+                    }
+
+                    warnings = infoLeft.warnings;
+                }
+
+                const infoRight = crawl(format.right, argIndex);
+                if (infoRight.status === Status.NotFoundFailure) {
+                    // It wasn't found. We can continue on from that since it was optional.
+                    return makeSuccess(argIndex, rank, warnings);
+                } else if (isFailure(infoRight.status)) {
+                    // It was an error.
+                    infoRight.status = Status.Failure;
+                    return infoRight;
+                }
+
+                argIndex = infoRight.argIndex;
+                rank += infoRight.rank;
+                warnings.concat(infoRight.warnings);
+
+                return makeSuccess(argIndex, rank, warnings);
+            } else if (format.kind === FormatKind.AndNext) {
+                let rank: number = 0;
+                let warnings: ArgumentWarning[] = [];
+
+                const infoLeft = crawl(format.left, argIndex);
+                if (isFailure(infoLeft.status)) {
+                    infoLeft.status = Status.Failure;
+                    return infoLeft;
+                }
+
+                rank += infoLeft.rank;
+                argIndex = infoLeft.argIndex;
+                warnings = warnings.concat(infoLeft.warnings);
+
+                const infoRight = crawl(format.right, argIndex);
+                if (isFailure(infoRight.status)) {
+                    infoRight.status = Status.Failure;
+                    // TODO: should we try wrapping the error or adding our own?
+                    return infoRight;
+                }
+
+                rank += infoRight.rank;
+                argIndex = infoRight.argIndex;
+                warnings = warnings.concat(infoRight.warnings);
+
+                return makeSuccess(argIndex, rank, warnings);
+            } else if (format.kind === FormatKind.Or) {
+                const infoLeft = crawl(format.left, argIndex);
+                if (!isFailure(infoLeft.status)) {
+                    return infoLeft;
+                }
+
+                const infoRight = crawl(format.right, argIndex);
+                if (!isFailure(infoRight.status)) {
+                    return infoRight;
+                }
+
+                // If we failed on both accounts, then we return the infoLeft version
+                // as our error, since that is the first version.
+                // That will somewhat let it ''select'' the error to be shown
+                // TODO: should we wrap the error or add our own?
+                // Note: We don't set this to Status.Failure, because NotFound errors need to 
+                // propagate from this
+                return infoLeft;
+            } else if (format.kind === FormatKind.Repeat) {
+                let rank: number = 0;
+                let warnings: ArgumentWarning[] = [];
+
+                while (true) {
+                    const info = crawl(format.right, argIndex);
+                    // Repeat handles errors by just.. stopping.
+                    // Because you might have crazy setups, and this will be caught
+                    // by other parts (probably).
+                    if (isFailure(info.status)) {
+                        break;
+                    }
+                    argIndex = info.argIndex;
+                    rank += info.rank;
+                    warnings = warnings.concat(info.warnings);
+                }
+
+                // We'll always succeed with a repeat, since it is zero or more.
+                return makeSuccess(argIndex, rank, warnings);
+            } else if (format.kind === FormatKind.Literal) {
+                let arg = args[argIndex];
+                if (arg === undefined) {
+                    return makeError(Status.NotFoundFailure, `Expected literal '${format.value}' but there was no argument`, argIndex);
+                }
+
+                // The success is the same for all, but their errors are different
+                // so it is constructed here to avoid repetitiveness. This is fine since
+                // `makeSuccess` is 'pure'.
+                const success = makeSuccess(argIndex + 1, correctRank);
+                if (isAlwaysArgument(arg)) {
+                    return success;
+                } else if (arg.type === ArgType.String) {
+                    if (arg.text === format.value) {
+                        return success;
+                    } else {
+                        return makeError(Status.Failure, `Found string, but its value was not the expected '${format.value}'`, argIndex, correctTypeRank);
+                    }
+                } else if (arg.type === ArgType.Bareword) {
+                    if (arg.value === format.value) {
+                        return success;
+                    } else {
+                        return makeError(Status.Failure, `Found text, but its value was not the expected '${format.value}'`, argIndex, correctTypeRank);
+                    }
+                } else if (
+                    // Handle cases that have their own ArgType but make sense to be literals.
+                    (format.value === 'null' && arg.type === ArgType.Null) ||
+                    (format.value === 'undefined' && arg.type === ArgType.Undefined) ||
+                    (format.value === 'true' && arg.type === ArgType.True) ||
+                    (format.value === 'false' && arg.type === ArgType.False) ||
+                    (format.value === 'NaN' && arg.type === ArgType.NaN)
+                ) {
+                    return success;
+                } else if (arg.type === ArgType.Number && arg.value.toString() === format.value) {
+                    // TODO: Due to IEEE-754 floats display not being completely sane to compare as
+                    // strings, it would probably be a good idea to warn the user if their format
+                    // contains literals that look like they're meant to be floats.
+                    return success;
+                } else {
+                    return makeError(Status.Failure, `Expected literal ('${format.value}'), but found:  `, argIndex);
+                }
+            } else if (format.kind === FormatKind.Type) {
+                const arg = args[argIndex];
+                const type = format.type;
+                if (arg === undefined) {
+                    return makeError(Status.NotFoundFailure, `Expected type '${type.name[0] || "UNNAMED TYPE"}' but there was no argument`, argIndex);
+                } else if (isAlwaysArgument(arg)) {
+                    return makeSuccess(argIndex + 1, correctRank);
+                }
+
+                const result = type.validate({
+                    arg,
+                    index: argIndex,
+                    arguments: args,
+                });
+
+                if (result instanceof Error) {
+                    // Failure
+                    return {
+                        argIndex,
+                        rank: 0,
+                        errors: [{
+                            error: result,
+                            index: argIndex,
+                        }],
+                        warnings: [],
+                        status: Status.Failure,
+                    };
+                } else if (result instanceof Warning) {
+                    // Success but we received a warning.
+                    // TODO: Slightly decrease the rank due to warning?
+                    return makeSuccess(argIndex + 1, correctRank, [{
+                        warning: result,
+                        index: argIndex,
+                    }]);
+                } else {
+                    // Success. (result === null)
+                    return makeSuccess(argIndex + 1, correctRank);
+                }
+            } else {
+                // Typescript thinks format is 'never' here, but if the error is removed then it
+                // thinks that not all paths exit
+                throw new Error(`Validator: Unhandled format kind`);
+            }
+        }
+
+        if (this.format === null) {
+            // TODO: is this sensible handling of no arguments or should we spit out an error here 
+            // if we got more?
+            // probably spit out an error since this is an empty variant?
+            return {
+                errors: [],
+                warnings: [],
+                rank: 0,
+                argIndex: 0,
+            };
+        }
+
+        const crawlInfo = crawl(this.format, 0);
+        // Remove extra parameters
+        return {
+            rank: crawlInfo.rank,
+            errors: crawlInfo.errors,
+            warnings: crawlInfo.warnings,
+            argIndex: crawlInfo.argIndex,
+        };
+    }
+
+    /**
+     * Limit on the number of 'iterations' the parser can perform.
+     * This may be too high.
+     * TODO: Allow this to be configured in the vscode settings.
+     */
+    private static ParserLimit: number = 2000;
+
+    /**
+     * Parses the format string into a tree of `Format` 'nodes'.
+     * @param formatString The format string to parse and validate
+     * @throws {Error}
+     */
+    private static parseFormat(formatString: UnparsedFormat): Format | null {
+        let lexed = Variant.lexFormat(formatString);
+        let index: number = 0;
+        // Keep track of iterations to avoid infinite loops.
+        let iterations: number = 0;
+
+        if (lexed.length === 0) {
+            return null;
+        }
+
+        // Pratt parser implementation derived from:
+        // https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html
+
+        // Binding Power: The higher the value the harder it binds relative to other binding powers.
+        // The binding power should _not_ be the same between operators unless they are really
+        // meant to be on the same 'level'. Such as + and -, or * and / in mathematics.
+        function infixBindingPower(op: FormatKind): [number, number] | null {
+            switch (op) {
+                case FormatKind.Or:
+                    return [9, 10];
+                case FormatKind.AndNext:
+                    return [4, 5];
+                case FormatKind.MaybeNext:
+                    // This binds _less* than `And-Then` because of cases like:
+                    // `alpha &+ 'start' |+ number |+ 'class' &+ text` to be parsed as
+                    // `alpha &+ ('start' |+ number) |+ ('class' &+ text)`
+                    return [2, 3]
+                default:
+                    return null;
+            }
+        }
+        function prefixBindingPower(op: FormatKind): number {
+            switch (op) {
+                // Currently and next is now allowed in prefix position as it is useless there.
+                // case FormatKind.AndNext:
+                //     return [1, 2];
+                case FormatKind.MaybeNext:
+                    // the pratt parsing article _does_ use higher values for the infix version of
+                    // + and -, but that is to make it bind harder than * and /, so that you can do
+                    // -4 * 3 -> (-4) * 3
+                    // but this is not higher than anything besides its infix companion.
+                    // So,
+                    // |+ a |+ b
+                    // would be:
+                    // (|+ a) |+ b
+                    // but if they were equivalent it wouldn't matter
+                    // If this was _lower_ for some reason then:
+                    // |+ (a |+ b)
+                    // but that doesn't have any change either.
+                    return 3;
+                case FormatKind.Repeat:
+                    // This should bind appropriately hard but less than the or operator.
+                    // Ex: ...a|b
+                    // parsing it as (...a)|b
+                    // Doesn't provide much utility commonly. Repeats of a or b.
+                    // More common is wanting ...(a|b)
+                    // And so this has a higher but less than or binding power
+                    // ... \+ a
+                    // Is pretty.. uh.. something, but it makes sense to parse it as
+                    // repeats of optional a or as a syntax error.
+                    return 8;
+                default:
+                    throw new Error("Parse: Unhandled operator in infix binding power of: " + op);
+            }
+        }
+
+        function isPrefixOperator(token: FormatLex): token is (FormatLexMaybeNext | FormatLexRepeat) {
+            return token.kind === FormatKind.MaybeNext || token.kind === FormatKind.Repeat;
+        }
+
+        function isValue(token: FormatLex): token is (FormatLiteral | FormatType) {
+            return token.kind === FormatKind.Literal || token.kind === FormatKind.Type;
+        }
+
+        function exprBp(minBp: number): Format {
+            iterations++;
+            if (iterations >= Variant.ParserLimit) {
+                throw new Error("Parser: Iterated too many times when parsing format. This might be an internal error, or due to a very complex input.");
+            }
+
+            if (!lexed[index]) {
+                throw new Error("Parse: Expected there to be a value at the given index.");
+            }
+
+            // The left-hand-side of the expression.
+            let lhs: Format;
+
+            const current: FormatLex = lexed[index];
+            index++;
+            if (isPrefixOperator(current)) {
+                const rBp = prefixBindingPower(current.kind);
+                const rhs = exprBp(rBp);
+                lhs = {
+                    kind: current.kind,
+                    range: current.range,
+                    right: rhs,
+                };
+            } else if (current.kind === FormatKind.Group) {
+                if (current.open) {
+                    lhs = exprBp(0);
+                    const after: FormatLex = lexed[index];
+                    if (after && after.kind === FormatKind.Group) {
+                        if (after.open) {
+                            throw new Error("Parse: Expected closing parentheses but found opening parentheses!");
+                        }
+                        // Otherwise, we're good. Advance past the closing paren
+                        index++;
+                    } else {
+                        throw new Error("Parse: Expected closing parentheses");
+                    }
+                } else {
+                    throw new Error("Parse: Did not expect opening parentheses");
+                }
+            } else if (isValue(current)) {
+                // Sanity: all lexed tokens that are values are the same as their format definitions
+                lhs = current;
+            } else {
+                throw new Error("Parse: Expected there to be literal or a type");
+            }
+
+            for (; ;) {
+                iterations++;
+                if (iterations >= Variant.ParserLimit) {
+                    throw new Error("Parser: Iterated too many times when parsing format operators. This might be an internal error, or due to a very complex input.");
+                }
+
+                const op = lexed[index];
+                if (op === undefined) break;
+                const bindingPower = infixBindingPower(op.kind);
+                if (bindingPower !== null) {
+                    let [lBp, rBp] = bindingPower;
+                    if (lBp < minBp) {
+                        break;
+                    }
+
+                    index++;
+                    const rhs = exprBp(rBp);
+
+                    // TODO: don't use as Format here to assure it that we're sane.
+                    lhs = {
+                        kind: op.kind,
+                        range: op.range,
+                        left: lhs,
+                        right: rhs,
+                    } as Format;
+                } else {
+                    break;
+                }
+            }
+
+            return lhs;
+        }
+
+        return exprBp(0);
+    }
+
+    /**
+     * The maximum number of iterations whilst parsing.
+     * This helps avoid bugs that cause it to process for too long, and most sane input would be
+     * less than this.
+     * TODO: Make this a settings option.
+     */
+    private static LexLimit: number = 1000;
+    private static Whitespace: RegExp = /\s/;
+    private static IdentifierStart: RegExp = /[a-zA-Z]/;
+    // Note: Currently this is the same as IdentifierStart, but could be expanded to allow numbers
+    // if desired.
+    private static Identifier: RegExp = /[a-zA-Z]/;
+    // Characters which the identifier parsing should stop at and let alternative parts of the code
+    // handle.
+    private static IdentifierStop: RegExp = /[\|\&\+\-\s\)\(]/;
+    private static Quote: RegExp = /[\'\"]/;
+    private static Digit: RegExp = /[0-9]/;
+
+    /**
+     * Turns the format string into a flat array of `FormatLex` (tokens essentially) for parsing.
+     * Also performs some limited validation. Has some special handling for likely common errors to
+     * provide better error messages.
+     * @param formatString The format for the parameters to be lexed.
+     * @throws {Error}
+     */
+    private static lexFormat(formatString: UnparsedFormat): FormatLex[] {
+        // Our index within the `formatString`.
+        let position: number = 0;
+        // The resulting tokens.
+        let lexed: FormatLex[] = [];
+        // Tracks the current number of iterations to avoid infinite loops or non-sane input.
+        let iterations = 0;
+
+        // Construct a range on the line.
+        // Ranges don't make 100% sense, since we're not in an actual document, but it works well
+        // enough, just having the line number be 0.
+        function makeRange(start: number, end: number, line: number = 0): vscode.Range {
+            return new vscode.Range(new vscode.Position(line, start), new vscode.Position(line, end));
+        }
+
+        // TODO: we could probably use the SugarCube lexer in arguments.ts since it is pretty good?
+        // TODO: If we don't do that, this could also be broken down into smaller component
+        // functions to make reading it easier, though that does make passing around the position
+        // state harder.
+        for (; ;) {
+            // Guard against infinite loops.
+            iterations++;
+            if (iterations >= Variant.LexLimit) {
+                throw new Error("Lex: Iterated too many times when parsing format. This might be an internal error, or a very long input string.");
+            }
+            if (position >= formatString.length) {
+                // We have finished parsing.
+                break;
+            }
+
+            let chr = formatString[position];
+            if (Variant.Whitespace.test(chr)) {
+                // Ignore it, whitespace only matters in literals.
+                position++;
+            } else if (chr === '&') {
+                // &+
+                let start = position;
+                // Consume &
+                position++;
+                let next = formatString[position];
+                if (next === '+') {
+                    // Consume +
+                    position++;
+                    lexed.push({
+                        kind: FormatKind.AndNext,
+                        range: makeRange(start, position),
+                    });
+                } else if (next === undefined) {
+                    throw new Error("Lex: Expected input to continue after `&`, did you mean to use `&+`? Content is still required after such.");
+                } else if (next === "-") {
+                    throw new Error("Lex: Found `&-`, did you mean to use `&+`?");
+                } else if (Variant.IdentifierStart.test(next) || Variant.Quote.test(next)) {
+                    throw new Error(`Lex: Found '&${next}', did you mean to do '&+${next}'?`);
+                } else {
+                    throw new Error(`Lex: Found invalid character after '&': '${next}'. Did you mean to use \`&+\`?`);
+                }
+            } else if (chr === '|') {
+                // | or |+
+                let start = position;
+                // Consume |
+                position++;
+                let next = formatString[position];
+                if (next === "+") {
+                    // |+
+                    // Consume +
+                    position++;
+                    lexed.push({
+                        kind: FormatKind.MaybeNext,
+                        range: makeRange(start, position),
+                    });
+                } else if (next === undefined) {
+                    throw new Error("Lex: Expected input to continue after `|`, did you mean to use `|+` or `|`? Content is still required after both.");
+                } else if (Variant.IdentifierStart.test(next) || Variant.Quote.test(next)) {
+                    // |
+                    lexed.push({
+                        kind: FormatKind.Or,
+                        range: makeRange(start, position),
+                    });
+                } else if (next === "-") {
+                    throw new Error("Lex: Found `|-`, did you mean to use `|+` or `&+`?");
+                } else {
+                    throw new Error(`Lex: Found invalid character after '|': '${next}'. Did you mean to use \`|+\`?`);
+                }
+            } else if (Variant.Quote.test(chr)) {
+                let openingQuote = chr;
+                // Start is at the quote.
+                let start = position;
+                position++;
+                while (true) {
+                    iterations++;
+                    if (iterations >= Variant.LexLimit) {
+                        throw new Error("Lex: Iterated too many times when parsing string. This might be an internal error, or a very long input string.");
+                    }
+
+                    let current = formatString[position];
+                    // TODO: Escape sequences:
+                    // \n,\t,\f?,\x?,\u?,\\,\",\'
+                    if (current === undefined) {
+                        throw new Error("Lex: Failed to parse string, found end of input before closing quote.");
+                    } else if (current === openingQuote) {
+                        // See code after while loop
+                        break;
+                    } else {
+                        // Simply increment the position.
+                        // We'll just slice it out of the string once it is done.
+                        position++;
+                    }
+                }
+
+                // This does not include the current position
+                // So this text contains the text within the string, without the quotation marks.
+                const text = formatString.slice(start + 1, position);
+                // TODO: We'll have t actually replace the escape sequences here?
+                // Skip past the closing quote.
+                position++;
+
+                lexed.push({
+                    kind: FormatKind.Literal,
+                    range: makeRange(start, position),
+                    value: text,
+                });
+            } else if (chr === '(' || chr === ')') {
+                const start = position;
+                position++;
+                lexed.push({
+                    kind: FormatKind.Group,
+                    range: makeRange(start, position),
+                    open: chr === '(',
+                });
+            } else if (Variant.IdentifierStart.test(chr)) {
+                let start = position;
+                position++;
+                while (true) {
+                    iterations++;
+                    if (iterations >= Variant.LexLimit) {
+                        throw new Error("Lex: Iterated too many times when parsing identifier. This might be an internal error, or a very long input string.");
+                    }
+
+                    let current = formatString[position];
+                    if (current === undefined || Variant.IdentifierStop.test(current)) {
+                        // See: After while loop
+                        break;
+                    } else if (Variant.Identifier.test(chr)) {
+                        // Consume this part of the identifier.
+                        position++;
+                    } else if (Variant.Quote.test(current)) {
+                        throw new Error(`Lex: Found quote mark (${current}) directly next to parameter type. Did you mean to use the \`|\` operator?`);
+                    } else if (Variant.Digit.test(current)) {
+                        throw new Error(`Lex: Found digit '${current}' after parameter type, but digits are not supported in those.`);
+                    } else {
+                        throw new Error(`Lex: Found invalid parameter type character: '${current}'.`);
+                    }
+                }
+
+                const identifier: string = formatString.slice(start, position);
+                let parameterType = findParameterType(identifier);
+                if (parameterType !== null) {
+                    lexed.push({
+                        kind: FormatKind.Type,
+                        range: makeRange(start, position),
+                        type: parameterType,
+                    });
+                } else {
+                    throw new Error(`Lex: Failed to find parameter type '${identifier}'.`);
+                }
+            } else if (chr === '.' && formatString[position + 1] === '.' && formatString[position + 2] === '.') {
+                let start = position;
+                // Consume ...
+                position += 3;
+
+                // Note: After the repeat should be an type|literal|group
+                lexed.push({
+                    kind: FormatKind.Repeat,
+                    range: makeRange(start, position),
+                });
+            } else if (chr === '+') {
+                throw new Error("Lex: Lone `+` symbol, did you mean to use `|+` or `&+`?");
+            } else if (chr === '`') {
+                throw new Error("Lex: Found ` character, did you mean to use single quote '?");
+            } else {
+                throw new Error(`Lex: Unrecognized symbol: '${chr}'`);
+            }
+        }
+
+        return lexed;
+    }
+}
+
+enum FormatKind {
+    // See: parameterTypes.
+    Type,
+    // 'text'
+    Literal,
+    // (format)
+    Group,
+    // format &+ format
+    AndNext,
+    // format |+ format
+    MaybeNext,
+    // format|format|format..
+    Or,
+    // ...
+    Repeat,
+}
+type FormatLex = FormatType | FormatLiteral | FormatLexGroup | FormatLexAndNext | FormatLexMaybeNext | FormatLexOr | FormatLexRepeat;
+interface FormatLexGroup {
+    kind: FormatKind.Group,
+    range: vscode.Range,
+    open: boolean,
+}
+interface FormatLexAndNext {
+    kind: FormatKind.AndNext,
+    range: vscode.Range,
+}
+interface FormatLexMaybeNext {
+    kind: FormatKind.MaybeNext,
+    range: vscode.Range,
+}
+interface FormatLexOr {
+    kind: FormatKind.Or,
+    range: vscode.Range,
+}
+interface FormatLexRepeat {
+    kind: FormatKind.Repeat,
+    range: vscode.Range,
+}
+
+// FormatKind (lexer) without the Group, since that does not appear.
+// Sadly this isn't an enum, so we still have to ues formatkind.
+type FormatParseKind = Exclude<FormatKind, FormatKind.Group>;
+type Format = FormatType | FormatLiteral | FormatAndNext | FormatMaybeNext | FormatOr | FormatRepeat;
+interface FormatType {
+    kind: FormatKind.Type,
+    range: vscode.Range,
+    type: ParameterType,
+}
+interface FormatLiteral {
+    kind: FormatKind.Literal,
+    // Range includes quotation marks.
+    range: vscode.Range,
+    // Does not include quotation marks.
+    value: string,
+}
+interface FormatAndNext {
+    kind: FormatKind.AndNext,
+    range: vscode.Range,
+    left: Format,
+    right: Format,
+}
+interface FormatMaybeNext {
+    kind: FormatKind.MaybeNext,
+    range: vscode.Range,
+    // If left is not set then it is unary
+    left?: Format,
+    right: Format,
+}
+interface FormatOr {
+    kind: FormatKind.Or,
+    range: vscode.Range,
+    left: Format,
+    right: Format,
+}
+interface FormatRepeat {
+    kind: FormatKind.Repeat,
+    range: vscode.Range,
+    right: Format,
+}
+
+/**
+ * Check if this is an argument that should always be allowed.
+ * This means: Variables, Accesses to settings, Accesses to setup, and expressions.
+ * This is done because we can't prove what values they have and so have to simply allow them,
+ * especially since they're so common.
+ * @param arg The argument to check
+ */
+function isAlwaysArgument(arg: Arg): arg is (VariableArgument | SettingsSetupAccessArgument | ExpressionArgument) {
+    if (arg === undefined) return false;
+    // Note: we don't include empty expressions since those are trivially not allowed.
+    return arg.type === ArgType.Variable || arg.type === ArgType.SettingsSetupAccess || arg.type === ArgType.Expression;
+}
+
+/**
+ * Format the tree as a.. tree. In text. Good for getting a better view of it from a reasoning level
+ * @param format The input tree.
+ * @param indent The amount of types [rep] should be indented.
+ * @param rep The text to use to indent. Can be set to an empty string for no indent
+ */
+function formatToTree(format: Format, indent: number = 0, rep: string = ' '): string {
+    const prefix = rep.repeat(indent);
+    if (format.kind === FormatKind.Type) {
+        return `${prefix}Type::${format.type.name[0]}\n`;
+    } else if (format.kind === FormatKind.Literal) {
+        return `${prefix}'${format.value}'\n`;
+    } else if (format.kind === FormatKind.AndNext) {
+        return `${prefix}AndNext\n${formatToTree(format.left, indent + 1, rep)}${formatToTree(format.right, indent + 1, rep)}`;
+    } else if (format.kind === FormatKind.MaybeNext) {
+        if (format.left) {
+            return `${prefix}MaybeNext\n${formatToTree(format.left, indent + 1, rep)}${formatToTree(format.right, indent + 1, rep)}`;
+        } else {
+            return `${prefix}AndNext\n${formatToTree(format.right, indent + 1, rep)}`;
+        }
+    } else if (format.kind === FormatKind.Or) {
+        return `${prefix}Or\n${formatToTree(format.left, indent + 1, rep)}${formatToTree(format.right, indent + 1, rep)}`;
+    } else if (format.kind === FormatKind.Repeat) {
+        return `${prefix}Repeat\n${formatToTree(format.right, indent + 1, rep)}`;
+    } else {
+        return `${prefix}UNHANDLED KIND`;
+    }
+}
+
+/**
+ * Formats it as a simple text, for relatively easy checking of how operator precedence is performed
+ * @param format The input tree.
+ */
+function formatToString(format: Format): string {
+    if (format.kind === FormatKind.Type) {
+        return format.type.name[0];
+    } else if (format.kind === FormatKind.Literal) {
+        return `'${format.value}'`;
+    } else if (format.kind === FormatKind.AndNext) {
+        // We use {} instead of () to disambiguate from actual parentheses
+        return `{${formatToString(format.left)} &+ ${formatToString(format.right)}}`;
+    } else if (format.kind === FormatKind.MaybeNext) {
+        if (format.left) {
+            return `{${formatToString(format.left)} |+ ${formatToString(format.right)}}`;
+        } else {
+            return `{|+ ${formatToString(format.right)}}`;
+        }
+    } else if (format.kind === FormatKind.Or) {
+        return `{${formatToString(format.left)}|${formatToString(format.right)}}`;
+    } else if (format.kind === FormatKind.Repeat) {
+        return `...{${formatToString(format.right)}}`
+    } else {
+        return `{UNHANDLED KIND}`;
+    }
+}


### PR DESCRIPTION
This pull request adds *Parameter Validation*.  
Summary: Parameter Validation is the ability to specify the format that macros can take their arguments in, and checking against that in the editor. This provides further error-checking (on-top of the Argument Parsing), making so even less manual checking of built passages and branches of code has to be done by the user of the extension.
It does this through a simple string format, with a number of features. The user documentation lies in the new docs folder, `/docs/parameters.md` (no clue how to link a file that is part of the PR before I even commit it).  
As explained in the document, there are a number of parameter types and operators for usage. This allows representing a sizable portion of the non-`skipArgs` macros.  
In the files, there are a number of TODOs and notes about potential future actions, but as of right now this PR has what it is meant to do and other additions should be done in a new PR. This one already adds over a thousand lines of code.  
  
![2021-01-12-193356_895x1000_scrot](https://user-images.githubusercontent.com/13157904/104398881-9b215e80-551d-11eb-8032-57bc8d818538.png)



For parsing the format string, I used a Pratt parser (precedence parser), adapted from: https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html (The Github repo is under MIT).  
If you were to look at the precedence, it goes:
- (Magical) Parentheses. (`c &+ (a |+ b)`). Technically not an operator in how the code treats it.
- (Infix) Or operator (`a|b`)
- (Prefix) Repeat operator (`...a`, `...(a)`)
    - NOTE: Since this is high, and under the or operator, one can do: `...a|b` which is equivalent to `...(a|b)`.
- (Infix) And-Then operator (`a &+ b`)
    - This is *higher* precedence than Maybe-Next, to allow for optional params like this to be written easier `a |+ 'start' &+ number |+ 'class' &+ text` <-> `a |+ ('start' &+ number) |+ ('class' &+ text)`
- (Prefix/Infix) Maybe-Next Operator (`a |+ b`)

## Future Ideas
This is a section for potential future parts of the parameter syntax and types, which are **not** included in this pull-request but could potentially be made into future ones. Any thoughts are welcome on them. They may be somewhat rambly, since they haven't been checked that thoroughly.
### Syntax
These are potential syntax extensions which make certain things easier or allowed certain setups that we don't currently enable.
- `!type`: Allows making it so it can not be of a specific type.
    This is most useful as a general manner to let a macro avoid variables by doing:  
    (ex: they want a literal): `text|!variable|!settingsSetupAccess|!expression` (would require these to be types, of which they are currently not).  
    This could also be done as being a joining operator like `|`:
    `text!variable!settingsSetupAccess!expression`, so text except for variables/settingsSetupAccesses/expressons. If the syntax was like this, would it bind less than `|` to allow `number|bool!scripting` -> `(number|bool)!scripting`?
    For sanity of people who want to do this, there'd probably be a one group for the listed three, name something like `scripting`, `always`, etc.  
    **Challenge**: Not too hard to implement really. Essentially just a check that the parameter type is valid, then when you do it you just error if it *doesn't* error. Probably might error on warnings too (`!linkNoSetter`, would this *require* a setter?)
    **Worth**: This provides some use in its ability to force the use of literal values in a macro. Not really done in the inbuilt macros.
- Some syntax for repeating mutually exclusive. Using `^` as example:  
    `^(a b c)` Don't really like the syntax. Essentially it is repeating (zero or more) which matches the different choices inside it; but once it has matched one 'variant' (oh no re-using terminology), then it would consider it an error to see it again.  
    Ex: `<<thing>>`, `<<thing a>>`, `<<thing a b>>`, `<<thing b a>>`, `<<thing c>>`, `<<thing c a b>>` etc, would be fine, but `<<thing a a>>`, `<<thing a b c a>>`, etc, would be errors.  
    **Challenge**: Not too challenging to bolt it on, though it does complicate parsing a bit in its current form and would probably force breaking the big parse loop into functions. Actually handling the operator wouldn't be that hard, since you can 'identify' them based on their index.  
    **Worth**: This is useful for macros that just loop over all their arguments and parse them out of order. The prime example being `<<audio>>` (See: https://github.com/tmedwards/sugarcube-2/blob/master/src/macros/macrolib.js#L2381), `createplaylist`'s `track` child, `masteraudio`, `playlist`, and `type`!  
    The way of writing the audio parameters that I came up with: `"text |+ 'load'|'pause'|'play'|'stop'|'unload'|'fadein'|'fadeout'|('fadeto' &+ number)|('fadeoverto' &+ text &+ number) |+ 'mute'|'unmute' |+ 'loop'|'unloop' |+ 'goto' &+ passage |+ 'time' &+ text |+ 'volume' &+ number"`, but this runs into issues because the order doesn't matter.  
    We could do repeated or-checks that allow that, but it would allow invalid input. For this reason, audio's parameters are not included in this PR.  
    Example with the theoretical syntax: `"text |+ ^('load'|'pause'|'play'|'stop'|'unload'|'fadein'|'fadeout'|('fadeto &+ number)|('fadeoverto' &+ text &+ number) 'mute'|'unmute' 'loop'|'unloop' ('goto' &+ passage) ('time' &+ text) ('volume' &+ number))"`  
    So, it could only be one of those variants, repeating until the end.  
### Types
These are proposed/potential types that are more complex than the simple ones this PR includes.
- `color` | `cssColor` | `CSSColor`:  
    A color that is valid in CSS. (`#FFAA00`, `#FA0`, `alicewhite`, maybe `rgb(0.3, 0.5, 0.6)`, maybe `rgba(0.3, 0.5, 0.6, 0.9)`).  
    This could also have smaller variations for custom user macros that are less fancy in their parsing: `hexColor`, `hexColorShort`, `colorName`, `rgbCall` | `rgb`, `rgbaCall` | `rgba`; respectively.  
    **Users**: My code! heh. None of the SugarCube macros need this, as it encourages doing styling with spans or the `@@` syntax.  
    **Challenge**: Pretty easy. The main pain point is having to store a table of all the 
- `selector`:  
    A selector for an element. Obviously can't be validated before runtime but we can check that it is sane.  
    Might have to disambiguate between CSS and JQuery valid selectors, unsure of their differences.
    This may be complicated to implement beyond basic id/class checking. May also make sense to have an `id`/`class` parameter type if this is added, because something might want to only accept 'one' element (represented by `id` in html/css).  
    **Users**: There are inbuilt SugarCube macros that could use this. (ex: `append`, `replace`, etc).  
    **Challenge**: Unknown, likely not trivial to perform beyond basic id/class checks.  
- `element` | `elementName` | `htmlElement` | `HTMLElement`:  
    The name of an element, (ex: `div`, `span`, `p`, etc). This could be emulated in the format already through excessive use of literals and the or operator.  
    **Users**: Inbuilt SugarCube macros (ex: `type`, ``).  
    **Challenge**: Most of the irritation comes from having a big list of valid html element names.  
- `time`:  
    Time. `1s`, `0s`, etc. Probably look at SugarCube to see how it handles it to match.  
    **Users**: Inbuilt SugarCube macros (ex: `type`, `repeat`, `timed`, `audio`)  
    **Challenge**: Not trivial, but not that complex probably.  
- `transition`:  
    This would just be `'transition'|'t8n'` since that is so common in the standard SugarCube. Though it is minor enough to not warrant it, it is not hard to add it and it would help shrink the size of the format string and avoid mistypes.  
    **Users**: Mostly the inbuilt SugarCube macro.
    **Challenge**: Trivial.
- `macroName`:  
    This would be a macro name that is defined in the macro definition files of the extension.  
    I'm somewhat iffy on this one.  
    The most obvious example is.. `widget`, but that is somewhat self-recursive to require it have a valid `macroName`.
    **Users**: Uh, like one inbuilt macro and some weird macros people might write.
    **Challenge**: Would require calling `macroList` from the argument parsing code, but that is easy.  
- `variableName` | `receiverName` | `receiver`:  
    The name of a inline/naked variable, the kind that you can use as an argument, but that must be text and not a literal variable. This is used by macros that do 'receiver', like `checkbox`.  
    **Users**: Inbuilt SugarCube macros, probably some user macros.  
    **Challenge**: Not too hard. The parsing for variables is pretty simple.  
- `decperc`:  
    A percentage between `0` and `1`. Ex: `0.43`, `1.0`, `1`, `0`, `0.9`.  
    Name could be better.  
    **Users**: `audio`'s volume parameters uses this.  
    **Challenge**: Trivial.

### Caching  
This currently does a lot of wasted work, because we've already parsed and validated the arguments before, so why do it repeatedly?  
I have an idea for caching both of those steps (arguments, and validation's errors/warnings) that would avoid invalidating cache on macro definition file changes (except for changed macros) using a hash on the input and essentially doing: `Record<MacroName, Record<HashOfUnparsedArguments, { errors, warnings }>>`  
(So hash arguments, store parsing information. Would drop it eventually, probably after it hasn't been seen in some amount of time. The hash lets us avoid storing duplicate strings and wasting memory.)  

Note1: Though, I'm unsure how it would behave *as you're typing*. I think currently the code updates as quickly as it can, but I'm unsure how well `collect` handles the temporary invalid states. Based on the argument parsing doesn't randomly make the whole file light up red randomly, it is probably not overly greedy in that case and should be fine.  
Note2: Need to think of a good hash for this use case. I, sadly, don't really know this that well so am uncertain as to a good one for potentially long strings. Choosing one that comes with VSCode (or electron) would be nice.  

### Oh No Variables
A theoretical idea, that probably wouldn't be implemented soon due to complexity but is related to this, would be the ability to specify the types of SugarCube variables. That way, when you write `<<link $player>>` (where `$player` is an object), it can tell you that it is invalid without even running.  
This could be done with *another* custom format (oh no, though simple types wouldn't be as hard as this PR), or using some existing type declaration system. I don't really know of any except for Typescript's declaration format, and I have no clue if there are libraries to parse those, how heavy they are, and how sane using Typescript's type system for that would be.  
Mostly just a musing of an idea than a formed one.    
  
## Closing  
So this adds the various stuff linked in the document, and makes it pretty easy to add new Parameter Types.  
There is a setting to disable the validation.    
Note: Currently this removes `skipArgs` on all the really basic macros that take 0 arguments always so that they can use the parameters to validate that they are taking nothing. It would be more efficient to allow skipArgs on them, and have parameters have a 'magic' value like `"none"` which avoids parsing and still checks. That can be done in a separate PR though.  
Note2: Similar to above, but in a future pr for macros that must have content like `<<print>>` or `<<if>>`, there could be 'magic' value like `"content"` or something to express that there must be text in argument positions.  
Note2: I wouldn't be surprised if there is some issues with this. It is a *large* amount of code. Hopefully it won't be anything too serious and it can be fixed.