### PR TITLE
Cache Argument-Parsing and Parameter-Validation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -195,6 +195,16 @@ export async function activate(context: vscode.ExtensionContext) {
 					fileGlob().forEach(file => prepare(file));
 				});
 			}
+			if (e.affectsConfiguration("twee3LanguageTools.sugarcube-2.cache.argumentInformation") && !vscode.workspace.getConfiguration("twee3LanguageTools.sugarcube-2.cache").get(".argumentInformation")) {
+				// The configuration for this setting has been changed and it is now false, so we
+				// clear the cache.
+				sc2m.argumentCache.clear();
+			}
+			if (e.affectsConfiguration("twee3LanguageTools.sugarcube-2.error.parameterValidation")) {
+				// Note: We simply clear the arguments cache to force it to revalidate.
+				// This could be done in a more efficient manner, but this is good enough.
+				sc2m.argumentCache.clear();
+			}
 		})
 		,
 		vscode.workspace.onDidCreateFiles(e => {
@@ -275,6 +285,12 @@ export async function activate(context: vscode.ExtensionContext) {
 		})
 		,
 		vscode.commands.registerCommand("twee3LanguageTools.sc2.defineMacro", sc2ca.unrecognizedMacroFixCommand)
+		,
+		vscode.commands.registerCommand("twee3LanguageTools.sc2.clearArgumentCache", () => {
+			// Provide a command to clear the argument cache for if there is ever any bugs with the
+			// implementation, it can tide users over until a fix.
+			sc2m.argumentCache.clear();
+		})
 		,
 		vscode.languages.registerCodeActionsProvider("twee3-sugarcube-2", new sc2ca.EndMacro(), {
 			providedCodeActionKinds: sc2ca.EndMacro.providedCodeActionKinds

--- a/src/sugarcube-2/arguments.ts
+++ b/src/sugarcube-2/arguments.ts
@@ -264,16 +264,14 @@ export interface StringArgument {
 	text: string,
 	range: vscode.Range,
 }
+
 /**
- * Parses the arguments passed into an ParsedArguments structure.
- * Returns a partial ParsedArguments structure if it failed, with the `valid` bool set to false.
- * @param macro The macro in the file, giving us a position to parse at. Should be the opening the
- * macro, otherwise an error is thrown.
- * @param macroDefinition The definition of the macro so that we can check it
- * @param text The text of the file
- * @throws {Error}
+ * Acquire a range over the macro's arguments.
+ * Returns null if it was a closing macro.
+ * @param macro
+ * @throws {Error} if macro is open
  */
-export function parseArguments(document: vscode.TextDocument, macro: macro, macroDefinition: macroDef): ParsedArguments {
+export function makeMacroArgumentsRange(macro: macro): vscode.Range {
 	if (!macro.open) {
 		throw new Error("Expected opening macro to parse arguments of.");
 	}
@@ -284,8 +282,23 @@ export function parseArguments(document: vscode.TextDocument, macro: macro, macr
 	// mistake
 	// Note: this means later places where we use positions within the text need to be offset to get
 	// accurate results.
-	let lexRange = new vscode.Range(afterMacroName, beforeMacroClose);
-	let source = document.getText(lexRange);
+	return new vscode.Range(afterMacroName, beforeMacroClose);
+}
+
+export type UnparsedMacroArguments = string;
+
+/**
+ * Parses the arguments passed into an ParsedArguments structure.
+ * Returns a partial ParsedArguments structure if it failed, with the `valid` bool set to false.
+ * @param macro The macro in the file, giving us a position to parse at. Should be the opening the
+ * macro, otherwise an error is thrown.
+ * @param macroDefinition The definition of the macro so that we can check it
+ * @param text The text of the file
+ * @throws {Error}
+ */
+export function parseArguments(document: vscode.TextDocument, macro: macro, macroDefinition: macroDef): ParsedArguments {
+	const lexRange = makeMacroArgumentsRange(macro);
+	let source: UnparsedMacroArguments = document.getText(lexRange);
 
 	function makeRange(item: LexerItem<MacroParse.Item>): vscode.Range {
 		// Note: Since we only ran the parser on a portion of the macro, we have to offset it

--- a/src/sugarcube-2/arguments.ts
+++ b/src/sugarcube-2/arguments.ts
@@ -296,10 +296,7 @@ export type UnparsedMacroArguments = string;
  * @param text The text of the file
  * @throws {Error}
  */
-export function parseArguments(document: vscode.TextDocument, macro: macro, macroDefinition: macroDef): ParsedArguments {
-	const lexRange = makeMacroArgumentsRange(macro);
-	let source: UnparsedMacroArguments = document.getText(lexRange);
-
+export function parseArguments(source: UnparsedMacroArguments, lexRange: vscode.Range, macro: macro, macroDefinition: macroDef): ParsedArguments {
 	function makeRange(item: LexerItem<MacroParse.Item>): vscode.Range {
 		// Note: Since we only ran the parser on a portion of the macro, we have to offset it
 		// in order to get the valid range.

--- a/src/sugarcube-2/macros.ts
+++ b/src/sugarcube-2/macros.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as yaml from 'yaml';
-import { Arg, parseArguments, ParsedArguments } from './arguments';
+import { Arg, makeMacroArgumentsRange, parseArguments, ParsedArguments, UnparsedMacroArguments } from './arguments';
 import { ArgumentError, ArgumentWarning, Parameters, parseMacroParameters } from './parameters';
 import * as macroListCore from './macros.json';
 
@@ -285,7 +285,9 @@ export const diagnostics = async function (document: vscode.TextDocument) {
 			}
 
 			if (el.open && !cur.skipArgs && vscode.workspace.getConfiguration("twee3LanguageTools.sugarcube-2.error").get("argumentParsing")) {
-				let parsedArguments: ParsedArguments = parseArguments(document, el, cur);
+				const lexRange: vscode.Range = makeMacroArgumentsRange(el);
+				const args: UnparsedMacroArguments = document.getText(lexRange);
+				let parsedArguments: ParsedArguments = parseArguments(args, lexRange, el, cur);
 				// Add any errors that we've found just from parsing to the diagnostics.
 				for (let i = 0; i < parsedArguments.errors.length; i++) {
 					let error = parsedArguments.errors[i];

--- a/src/sugarcube-2/macros.ts
+++ b/src/sugarcube-2/macros.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as yaml from 'yaml';
-import { Arg, makeMacroArgumentsRange, parseArguments, ParsedArguments, UnparsedMacroArguments } from './arguments';
-import { ArgumentError, ArgumentWarning, Parameters, parseMacroParameters } from './parameters';
+import { Arg, ArgumentParseError, makeMacroArgumentsRange, parseArguments, ParsedArguments, UnparsedMacroArguments } from './arguments';
+import { ArgumentError, ArgumentWarning, ChosenVariantInformation, isArrayEqual, Parameters, parseMacroParameters } from './parameters';
 import * as macroListCore from './macros.json';
 
 export type MacroName = string;
@@ -84,6 +84,21 @@ const updateMacroCache = async function () {
 		vscode.window.showErrorMessage(`Errors encountered parsing parameters of macros: \n${errorMessages}`);
 	}
 
+	// Check for changed macros and clear those from the arguments cache.
+	if (macroCache !== null) {
+		for (const key in macroCache) {
+			if (key in list) {
+				if (!isMacroFunctionallyEquivalent(macroCache[key], list[key])) {
+					// They weren't equivalent, thus we remove it from cache.
+					argumentCache.clearMacro(key);
+				}
+			} else {
+				// The macro no longer exists. Remove it from cache.
+				argumentCache.clearMacro(key);
+			}
+		}
+	}
+
 	macroCache = list;
 }
 
@@ -107,6 +122,37 @@ const parseMacroList = async function () {
 
 	return list;
 };
+
+
+/**
+ * Check if two macro definition are functionally equivalent.
+ * Essentially a _loose_ check for if they would produce the same behavior. It errs on the side of
+ * caution (and performance).
+ */
+function isMacroFunctionallyEquivalent(left: macroDef, right: macroDef): boolean {
+	if (left.parameters === undefined || right.parameters === undefined) {
+		if (left.parameters !== right.parameters) {
+			// One of them is undefined whilst the other is not.
+			return false;
+		}
+	} else {
+		// They are both non-undefined
+		if (!left.parameters.compare(right.parameters)) {
+			return false;
+		}
+	}
+	// Both of the above checks fall through in the valid case and we don't have to have ugly 
+	// checks in the boolean expression below
+
+	return left.name === right.name &&
+		left.container === right.container &&
+		left.selfClose === right.selfClose &&
+		isArrayEqual(left.children, right.children) &&
+		isArrayEqual(left.parents, right.parents) &&
+		left.deprecated === right.deprecated &&
+		isArrayEqual(left.deprecatedSuggestions, right.deprecatedSuggestions) &&
+		left.skipArgs === right.skipArgs;
+}
 
 export const collect = async function (raw: string) {
 	const list = await macroList();
@@ -199,6 +245,116 @@ export const collect = async function (raw: string) {
 	return { list, macros };
 };
 
+interface ArgumentCacheEntry {
+	parsed: ParsedArguments,
+	// This is null in several cases: errors in argument parsing, the setting being off, and there
+	// being no parameters field on the macro definition.
+	variant: ChosenVariantInformation | null,
+	// The time it was last accessed at, used for dumping it from the cache.
+	lastAccess: number,
+}
+/**
+ * A class to cache results from parsing and validating arguments.
+ * This will minor hurt performance in the initial parsing, but most argument parsing/validation is
+ * the same as it was previously and so will help avoid abusing the user's cpu.
+ */
+class ArgumentCache {
+	// So, the first level is the MacroName. This lets us identify the macro it is for easier.
+	// Which is useful for two reasons
+	// 	1. It lets us quickly clear all the entries under that macro name, such as when it is
+	// 		updated in the settings file.
+	//  2. (Primary reason). We can just use the arguments as the cache key, and so even if two
+	//  	macro invocations have the same arguments they won't collide. Pretty simple, very little
+	// 		special handling.
+	// We use the arguments as the second ''level''-key so that it can be identified.
+	// We do this rather than computing a hash for it ourselves, because the v8 engine already does
+	// this in almost certainly a far better manner than we do.
+	// Though there is a downside in memory due to storing these strings instead of a far smaller
+	// hash computed by ourselves, it was deemed 'probably fine' after.. much thought.
+	private cache: Record<MacroName, Record<UnparsedMacroArguments, ArgumentCacheEntry>>
+
+	private cacheCleanerInterval: NodeJS.Timeout | undefined;
+
+	constructor() {
+		this.cache = Object.create(null);
+		this.initializeCacheCleaner();
+	}
+
+	// TODO: let this be user customizable
+	// 5 minutes
+	private static cacheCleanerDelay: number = (1000 * 60) * 5;
+	private initializeCacheCleaner() {
+		if (this.cacheCleanerInterval !== undefined) {
+			clearInterval(this.cacheCleanerInterval);
+		}
+
+		this.cacheCleanerInterval = setInterval(() => {
+			this.cleanCache();
+		}, ArgumentCache.cacheCleanerDelay);
+	}
+
+	// TODO: let this be user customizable
+	// 5 minutes
+	// The amount of time between the last access and now before it is allowed to be removed.
+	private static cacheMinLastAccess: number = (1000 * 60) * 2;
+	cleanCache() {
+		let current = Date.now();
+		for (const name in this.cache) {
+			for (const args in this.cache[name]) {
+				if (current - this.cache[name][args].lastAccess >= ArgumentCache.cacheMinLastAccess) {
+					delete this.cache[name][args];
+				}
+			}
+		}
+	}
+
+	/**
+	 * Clear the entire cache.
+	 */
+	clear() {
+		this.cache = Object.create(null);
+	}
+
+	/**
+	 * Clear a specific macro from the cache. This is used for when macro definitions are updated
+	 * which can change parsing despite having the same arguments
+	 * @param name The name of the macor
+	 */
+	clearMacro(name: MacroName) {
+		if (name in this.cache) {
+			delete this.cache[name];
+		}
+	}
+
+	/**
+	 * Gets a cache entry, otherwise creates it with the given `construct` function.
+	 * @param name The name of the macro.
+	 * @param args The string of arguments that the macro received
+	 * @param construct A function to construct the entry if it did not exist.
+	 */
+	getInsert(name: MacroName, args: UnparsedMacroArguments, construct: () => ArgumentCacheEntry): ArgumentCacheEntry {
+		// If caching is not enabled, we just make the cache immediately construct and return
+		// without storing it.
+		if (!vscode.workspace.getConfiguration("twee3LanguageTools.sugarcube-2.cache").get("argumentInformation")) {
+			return construct();
+		}
+
+
+		if (!(name in this.cache)) {
+			this.cache[name] = Object.create(null);
+		}
+
+		if (!(args in this.cache[name])) {
+			// Even if this errors, the cache should still be in a valid state.
+			this.cache[name][args] = construct();
+		}
+
+		this.cache[name][args].lastAccess = Date.now();
+		return this.cache[name][args];
+	}
+}
+export const argumentCache: ArgumentCache = new ArgumentCache();
+
 export const diagnostics = async function (document: vscode.TextDocument) {
 	let d: vscode.Diagnostic[] = [];
 
@@ -287,7 +443,27 @@ export const diagnostics = async function (document: vscode.TextDocument) {
 			if (el.open && !cur.skipArgs && vscode.workspace.getConfiguration("twee3LanguageTools.sugarcube-2.error").get("argumentParsing")) {
 				const lexRange: vscode.Range = makeMacroArgumentsRange(el);
 				const args: UnparsedMacroArguments = document.getText(lexRange);
-				let parsedArguments: ParsedArguments = parseArguments(args, lexRange, el, cur);
+
+				// TODO: Potential future feature would making the cache simply hold the
+				// diagnostics themselves rather than reconstructing them each time.
+				const cacheEntry = argumentCache.getInsert(el.name, args, () => {
+					const parsedArguments: ParsedArguments = parseArguments(args, lexRange, el, cur);
+					let chosenVariant: ChosenVariantInformation | null = null;
+					if (parsedArguments.errors.length === 0 && vscode.workspace.getConfiguration("twee3LanguageTools.sugarcube-2.error").get("parameterValidation") && cur.parameters instanceof Parameters) {
+						const parameters: Parameters = cur.parameters;
+						chosenVariant = parameters.validate(parsedArguments);
+					}
+
+					return {
+						parsed: parsedArguments,
+						variant: chosenVariant,
+						lastAccess: Date.now(),
+					};
+				});
+
+				const parsedArguments = cacheEntry.parsed;
+				const highestVariant = cacheEntry.variant;
+
 				// Add any errors that we've found just from parsing to the diagnostics.
 				for (let i = 0; i < parsedArguments.errors.length; i++) {
 					let error = parsedArguments.errors[i];
@@ -300,14 +476,8 @@ export const diagnostics = async function (document: vscode.TextDocument) {
 					});
 				}
 
-				// Perform parameter validation.
-				// Requires a setting to be enabled and it to be a parsed instance of parameters.
-				// As well, we currently don't try checking if there was errors in parsing the 
-				// arguments.
-				if (parsedArguments.errors.length === 0 && vscode.workspace.getConfiguration("twee3LanguageTools.sugarcube-2.error").get("parameterValidation") && cur.parameters instanceof Parameters) {
+				if (vscode.workspace.getConfiguration("twee3LanguageTools.sugarcube-2.error").get("parameterValidation") && highestVariant !== null && cur.parameters instanceof Parameters) {
 					const parameters: Parameters = cur.parameters;
-					const highestVariant = parameters.validate(parsedArguments);
-
 					if (highestVariant.variantKey === null) {
 						if (parameters.isEmpty()) {
 							// There are no parameters!

--- a/src/sugarcube-2/macros.ts
+++ b/src/sugarcube-2/macros.ts
@@ -4,10 +4,11 @@ import { Arg, parseArguments, ParsedArguments } from './arguments';
 import { ArgumentError, ArgumentWarning, Parameters, parseMacroParameters } from './parameters';
 import * as macroListCore from './macros.json';
 
+export type MacroName = string;
 export interface macro {
 	id: number;
 	pair: number;
-	name: string;
+	name: MacroName;
 	open: boolean;
 	selfClosed: boolean;
 	endVariant: boolean;
@@ -15,7 +16,7 @@ export interface macro {
 }
 
 export interface macroDef {
-	name?: string;
+	name?: MacroName;
 	description?: string,
 	parameters?: Parameters,
 	container?: boolean;


### PR DESCRIPTION
This PR helps with issue #14 and performs the idea for caching mentioned in PR #15.  
This implements caching for argument parsing results (the parsed arguments, errors, and warnings), and for parameter validation results (the errors, warnings, and the variant).  
With this, it no longer parses and validates macro parameters in the current file every time the user interacts with the document (aka when `diagnostics` is called).  
The cache stores the entries by their argument strings (per macro, so there is no cross-macro caching), which should be efficient due to v8 being Good-At-That(tm). (See: https://v8.dev/blog/hash-code for fun reading). This is done rather than hashing it ourselves because that would require finding a good hash implementation (of which I am not experienced at) for potentially quite long inputs. v8's hashing will be far more efficient, and most certainly better. The downside of using the arguments as the keys is that now it keeps around the argument strings, using up memory, though this likely is minor.  
There are a variety of places the cache could be improved for further performance/memory gains, (Better macro comparisons, allowing tuning of times, only dropping cache entries on files we aren't currently looking at, updating better on parameter validation settings, handling arguments changing as user types, etc), but it is good-enough and those would not be challenging to implement if they deemed to be needed in the future.