### PR TITLE
Arguments/Parameters Passage Validity Checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,6 +251,11 @@
 					"type": "boolean",
 					"default": true,
 					"markdownDescription": "Provide errors about invalid parameter types being passed into macros? Depends upon `argumentParsing`."
+				},
+				"twee3LanguageTools.sugarcube-2.warning.barewordLinkPassageChecking": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "Provides warnings for links like `[[passage]]` when `passage` is not a valid passage name. This could cause false positives in cases where you are using a global variable."
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -307,6 +307,11 @@
 				"command": "twee3LanguageTools.ifid.generate",
 				"title": "Generate IFID",
 				"category": "Twee3 Language Tools"
+			},
+			{
+				"command": "twee3LanguageTools.sc2.clearArgumentCache",
+				"title": "Clear Argument Cache",
+				"category": "Twee3 Language Tools"
 			}
 		],
 		"menus": {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import headsplit from './headsplit';
 import { diagnostics as sc2 } from './sugarcube-2/macros';
 
-export const updateDiagnostics = async function (document: vscode.TextDocument, collection: vscode.DiagnosticCollection) {
+export const updateDiagnostics = async function (ctx: vscode.ExtensionContext, document: vscode.TextDocument, collection: vscode.DiagnosticCollection) {
 	if (!/^twee3.*/.test(document.languageId)) return;
 
 	let diagnostics: vscode.Diagnostic[] = [];
@@ -41,7 +41,7 @@ export const updateDiagnostics = async function (document: vscode.TextDocument, 
 		}
 	});
 
-	if (document.languageId === "twee3-sugarcube-2") diagnostics = diagnostics.concat(await sc2(document));
+	if (document.languageId === "twee3-sugarcube-2") diagnostics = diagnostics.concat(await sc2(ctx, document));
 
 	collection.set(document.uri, diagnostics);
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,6 +205,9 @@ export async function activate(context: vscode.ExtensionContext) {
 				// This could be done in a more efficient manner, but this is good enough.
 				sc2m.argumentCache.clear();
 			}
+			if (e.affectsConfiguration("twee3LanguageTools.sugarcube-2.warningbarewordLinkPassageChecking")) {
+				sc2m.argumentCache.clearMacrosUsingPassage();
+			}
 		})
 		,
 		vscode.workspace.onDidCreateFiles(e => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,6 +128,11 @@ export async function activate(context: vscode.ExtensionContext) {
 		}, true);
 	}
 
+	passageListProvider.onDidChangeTreeData(x => {
+    	// Update any argument/parameters that may depend on passages.
+    	sc2m.argumentCache.clearMacrosUsingPassage();
+	});
+
 	ctx.subscriptions.push(
 		vscode.languages.registerDocumentSemanticTokensProvider(documentSelector, new DocumentSemanticTokensProvider(), legend)
 		,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,7 +114,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	function prepare(file: string) {
 		vscode.workspace.openTextDocument(file).then(async doc => {
 			tweeProjectConfig(doc);
-			updateDiagnostics(doc, collection);
+			updateDiagnostics(ctx, doc, collection);
 			await parseText(ctx, doc);
 			if (vscode.workspace.getConfiguration("twee3LanguageTools.passage").get("list"))  passageListProvider.refresh();
 		})
@@ -160,17 +160,17 @@ export async function activate(context: vscode.ExtensionContext) {
 		,
 		vscode.window.onDidChangeActiveTextEditor(editor => {
 			if (editor) {
-				updateDiagnostics(editor.document, collection);
+				updateDiagnostics(ctx, editor.document, collection);
 			}
 		})
 		,
 		vscode.workspace.onDidOpenTextDocument(document => {
 			changeStoryFormat(document);
-			updateDiagnostics(document, collection);
+			updateDiagnostics(ctx, document, collection);
 		})
 		,
 		vscode.workspace.onDidChangeTextDocument(e => {
-			updateDiagnostics(e.document, collection);
+			updateDiagnostics(ctx, e.document, collection);
 		})
 		,
 		vscode.workspace.onDidChangeConfiguration(e => {
@@ -178,7 +178,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				fileGlob().forEach(file => {
 					vscode.workspace.openTextDocument(file).then(doc => {
 						changeStoryFormat(doc);
-						updateDiagnostics(doc, collection);
+						updateDiagnostics(ctx, doc, collection);
 					})
 				});
 			}
@@ -243,7 +243,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		,
 		vscode.commands.registerCommand("twee3LanguageTools.refreshDiagnostics", () => {
 			let doc = vscode.window.activeTextEditor?.document;
-			if (doc) updateDiagnostics(doc, collection);
+			if (doc) updateDiagnostics(ctx, doc, collection);
 		})
 		,
 		vscode.commands.registerCommand("twee3LanguageTools.passage.jump", (item: Passage) => {

--- a/src/sugarcube-2/LICENSE
+++ b/src/sugarcube-2/LICENSE
@@ -2,6 +2,7 @@ Major chunks of the following files in this project:
 - arguments.ts
 - macros.json
 - macros.ts
+- validation.ts
 are adapted from Thomas Michael Edwards's SugarCube-2 (https://github.com/tmedwards/sugarcube-2/)
 which is licensed under the BSD 2-Clause "Simplified" License, which is essentially compatible
 with  the MIT License that this project uses.

--- a/src/sugarcube-2/arguments.ts
+++ b/src/sugarcube-2/arguments.ts
@@ -2,7 +2,7 @@ import { info } from 'console';
 import * as vscode from 'vscode';
 import { Passage } from '../tree-view';
 import { macro, macroDef } from "./macros";
-import { evalPassageId, Evaluatable, evaluateTwineScriptString, StateInfo, Warning } from './validation';
+import { evalPassageId, Evaluatable, evaluateTwineScriptString, notSpaceRegex, settingsSetupAccessRegexp, spaceRegex, StateInfo, varTestRegexp, Warning } from './validation';
 
 // Note: Much of this file has come from SugarCube2, though it is modified for simplicities sake.
 
@@ -501,9 +501,8 @@ export function parseArguments(source: UnparsedMacroArguments, lexRange: vscode.
  * @param warningsOutput an array to output a warning if we get one
  */
 function checkPassageId(passages: Passage[], passage: string, range: vscode.Range, warningsOutput: ArgumentParseWarning[]): Evaluatable<string, string> {
-	const argPassage = evalPassageId(passages, passage);
+	const argPassage = evalPassageId(passages, passage, vscode.workspace.getConfiguration("twee3LanguageTools.sugarcube-2.warning").get("barewordLinkPassageChecking"));
 	if (argPassage.isEvaluated) {
-		console.log("Checking", argPassage.value);
 		if (!passages.find(passage => passage.name === argPassage.value)) {
 			warningsOutput.push({
 				kind: ArgumentParseWarningKind.InvalidPassageName,
@@ -616,13 +615,6 @@ function isExternalLink(link: string) {
 
 // Much of the code following this is essentially modified SugarCube code, though
 // for the most part just adding types and changing small parts.
-
-// SugarCube has more complex checks for these, but we're only supporting VSCode and assume its
-// whitespace handling is sane.
-const notSpaceRegex: RegExp = /\S/;
-const spaceRegex: RegExp = /\s/;
-const varTestRegexp: RegExp = /^[$_][$A-Z_a-z][$0-9A-Z_a-z]*/;
-const settingsSetupAccessRegexp: RegExp = /^(?:settings|setup)[.[]/;
 
 namespace MacroParse {
 	export enum Item {

--- a/src/sugarcube-2/arguments.ts
+++ b/src/sugarcube-2/arguments.ts
@@ -460,7 +460,7 @@ export function parseArguments(source: UnparsedMacroArguments, lexRange: vscode.
 							arg.setter = markup.setter;
 						}
 						if (markup.link) {
-							arg.passage = checkPassageId(state.passages, markup.source as string, range, args.warnings);
+							arg.passage = checkPassageId(state.passages, markup.link as string, range, args.warnings);
 						}
 						args.arguments.push(arg);
 					} else if (markup.isImage) {
@@ -503,6 +503,7 @@ export function parseArguments(source: UnparsedMacroArguments, lexRange: vscode.
 function checkPassageId(passages: Passage[], passage: string, range: vscode.Range, warningsOutput: ArgumentParseWarning[]): Evaluatable<string, string> {
 	const argPassage = evalPassageId(passages, passage);
 	if (argPassage.isEvaluated) {
+		console.log("Checking", argPassage.value);
 		if (!passages.find(passage => passage.name === argPassage.value)) {
 			warningsOutput.push({
 				kind: ArgumentParseWarningKind.InvalidPassageName,

--- a/src/sugarcube-2/arguments.ts
+++ b/src/sugarcube-2/arguments.ts
@@ -1,5 +1,8 @@
+import { info } from 'console';
 import * as vscode from 'vscode';
+import { Passage } from '../tree-view';
 import { macro, macroDef } from "./macros";
+import { evalPassageId, Evaluatable, evaluateTwineScriptString, StateInfo, Warning } from './validation';
 
 // Note: Much of this file has come from SugarCube2, though it is modified for simplicities sake.
 
@@ -151,6 +154,9 @@ export interface ParsedArguments {
 	/// Errors encountered whilst parsing
 	/// If this has entries then it may mean that the rest of the arguments were not parsed
 	errors: ArgumentParseError[],
+	/// Warnings about parts that have been parsed. These are ones we can manage to skip past and
+	// continue, usually due to guessing what you meant.
+	warnings: ArgumentParseWarning[],
 	arguments: Arg[],
 }
 export enum ArgumentParseErrorKind {
@@ -163,17 +169,15 @@ export interface ArgumentParseError {
 	message?: string,
 	range: vscode.Range,
 }
-
-/**
- * An interfact for data which could have evaluatable data within it, but might not!
- * `T`: The type that would result from evaluating it. (Not that we can do that)
- * `B`: The original type (usually string).
- */
-export interface Evaluatable<T, B> {
-	original: B,
-	isEvaluated: boolean,
-	value?: T
+export enum ArgumentParseWarningKind {
+	InvalidPassageName,
 }
+export interface ArgumentParseWarning {
+	kind: ArgumentParseWarningKind,
+	message?: string,
+	range: vscode.Range,
+}
+
 
 export enum ArgType {
 	// These are from link
@@ -296,7 +300,7 @@ export type UnparsedMacroArguments = string;
  * @param text The text of the file
  * @throws {Error}
  */
-export function parseArguments(source: UnparsedMacroArguments, lexRange: vscode.Range, macro: macro, macroDefinition: macroDef): ParsedArguments {
+export function parseArguments(source: UnparsedMacroArguments, lexRange: vscode.Range, macro: macro, macroDefinition: macroDef, state: StateInfo): ParsedArguments {
 	function makeRange(item: LexerItem<MacroParse.Item>): vscode.Range {
 		// Note: Since we only ran the parser on a portion of the macro, we have to offset it
 		// in order to get the valid range.
@@ -315,6 +319,7 @@ export function parseArguments(source: UnparsedMacroArguments, lexRange: vscode.
 
 	let args: ParsedArguments = {
 		errors: [],
+		warnings: [],
 		arguments: [],
 	};
 
@@ -455,14 +460,14 @@ export function parseArguments(source: UnparsedMacroArguments, lexRange: vscode.
 							arg.setter = markup.setter;
 						}
 						if (markup.link) {
-							arg.passage = evalPassageId(markup.link);
+							arg.passage = checkPassageId(state.passages, markup.source as string, range, args.warnings);
 						}
 						args.arguments.push(arg);
 					} else if (markup.isImage) {
 						let arg: ImageArgument = {
 							type: ArgType.Image,
 							// TODO: should we assume that source is a string?
-							image: evalPassageId(markup.source as string),
+							image: checkPassageId(state.passages, markup.source as string, range, args.warnings),
 							range,
 						};
 
@@ -475,7 +480,7 @@ export function parseArguments(source: UnparsedMacroArguments, lexRange: vscode.
 						}
 
 						if (markup.hasOwnProperty('link')) {
-							arg.passage = evalPassageId(markup.link as string);
+							arg.passage = checkPassageId(state.passages, markup.link as string, range, args.warnings);
 						}
 
 						if (markup.hasOwnProperty('setter')) {
@@ -489,6 +494,27 @@ export function parseArguments(source: UnparsedMacroArguments, lexRange: vscode.
 	}
 	return args;
 }
+
+/**
+ *
+ * @param passage The unevaluated twinescript for a passage
+ * @param warningsOutput an array to output a warning if we get one
+ */
+function checkPassageId(passages: Passage[], passage: string, range: vscode.Range, warningsOutput: ArgumentParseWarning[]): Evaluatable<string, string> {
+	const argPassage = evalPassageId(passages, passage);
+	if (argPassage.isEvaluated) {
+		if (!passages.find(passage => passage.name === argPassage.value)) {
+			warningsOutput.push({
+				kind: ArgumentParseWarningKind.InvalidPassageName,
+				message: "Nonexistent passage",
+				range,
+			});
+		}
+	}
+	return argPassage;
+}
+
+
 
 
 interface MarkupInput {
@@ -586,13 +612,6 @@ function isExternalLink(link: string) {
 	return urlRegExp.test(link) || /[/.?#]/.test(link);
 }
 
-function evalPassageId(passage: string): Evaluatable<string, string> {
-	// TODO: check if the passage exists.
-	return {
-		original: passage,
-		isEvaluated: false,
-	};
-}
 
 // Much of the code following this is essentially modified SugarCube code, though
 // for the most part just adding types and changing small parts.

--- a/src/sugarcube-2/macros.ts
+++ b/src/sugarcube-2/macros.ts
@@ -3,6 +3,7 @@ import * as yaml from 'yaml';
 import { Arg, ArgumentParseError, makeMacroArgumentsRange, parseArguments, ParsedArguments, UnparsedMacroArguments } from './arguments';
 import { ArgumentError, ArgumentWarning, ChosenVariantInformation, isArrayEqual, Parameters, parseMacroParameters } from './parameters';
 import * as macroListCore from './macros.json';
+import { Passage } from '../tree-view';
 
 export type MacroName = string;
 export interface macro {
@@ -355,10 +356,11 @@ class ArgumentCache {
 }
 export const argumentCache: ArgumentCache = new ArgumentCache();
 
-export const diagnostics = async function (document: vscode.TextDocument) {
+export const diagnostics = async function (ctx: vscode.ExtensionContext, document: vscode.TextDocument) {
 	let d: vscode.Diagnostic[] = [];
 
 	let collected = await collect(document.getText());
+	const passages: Passage[] = ctx.workspaceState.get("passages", []);
 
 	collected.macros.forEach(el => {
 		let cur: macroDef;
@@ -451,7 +453,9 @@ export const diagnostics = async function (document: vscode.TextDocument) {
 					let chosenVariant: ChosenVariantInformation | null = null;
 					if (parsedArguments.errors.length === 0 && vscode.workspace.getConfiguration("twee3LanguageTools.sugarcube-2.error").get("parameterValidation") && cur.parameters instanceof Parameters) {
 						const parameters: Parameters = cur.parameters;
-						chosenVariant = parameters.validate(parsedArguments);
+						chosenVariant = parameters.validate(parsedArguments, {
+							passages,
+						});
 					}
 
 					return {

--- a/src/sugarcube-2/macros.ts
+++ b/src/sugarcube-2/macros.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
 import * as yaml from 'yaml';
 import { Arg, ArgumentParseError, makeMacroArgumentsRange, parseArguments, ParsedArguments, UnparsedMacroArguments } from './arguments';
-import { ArgumentError, ArgumentWarning, ChosenVariantInformation, isArrayEqual, Parameters, parseMacroParameters } from './parameters';
+import { ArgumentError, ArgumentWarning, ChosenVariantInformation, Parameters, parseMacroParameters } from './parameters';
 import * as macroListCore from './macros.json';
 import { Passage } from '../tree-view';
+import { isArrayEqual } from './validation';
 
 export type MacroName = string;
 export interface macro {

--- a/src/sugarcube-2/parameters.ts
+++ b/src/sugarcube-2/parameters.ts
@@ -1,21 +1,11 @@
 import * as vscode from 'vscode';
 import { Passage } from '../tree-view';
 import { Arg, ArgType, ExpressionArgument, ParsedArguments, SettingsSetupAccessArgument, VariableArgument } from './arguments';
+import { StateInfo, Warning } from './validation';
 
 export type UnparsedFormat = string;
 // Note: This may eventually also be allowed to become an object, for more configuration options.
 export type UnparsedVariant = UnparsedFormat;
-
-// The warning class is for things that are technically 'errors' (in that they are invalid)
-// but are likely just slightly incorrect and so should be counted as at least a partial validity
-// for a given variant. (Ex: Passing a link with a setter to something that takes `linkNoSetter`)
-export class Warning {
-    readonly message: string;
-
-    constructor(message: string) {
-        this.message = message;
-    }
-}
 
 /**
  * Helper function for constructing simple paramter types without the boilerplate
@@ -188,13 +178,6 @@ export function parseMacroParameters(list: Record<string, Record<string, any>>):
         }
     }
     return errors;
-}
-
-/**
- * Information about the state, used for verifying some parts of the parameters.
- */
-export interface StateInfo {
-    passages: Passage[],
 }
 
 export interface ChosenVariantInformation {
@@ -1155,31 +1138,6 @@ export function compareFormat(left: Format, right: Format): boolean {
         // Unequal kind
         return false;
     }
-}
-
-
-/**
- * Simple function for if checking each of two array's elements are equal.
- * Uses triple-equals and does not do any recursive calls on sub-arrays.
- * Has the option to take undefined arrays, because that is just better for the place it is used in.
- */
-export function isArrayEqual<T>(left?: T[], right?: T[]): boolean {
-    if (left === right) {
-        // They're the same array, or both undefined
-        return true;
-    } else if (left === undefined || right === undefined) {
-        // We already checked for equality, so if either are undefined then we know it isn't equal
-        return false;
-    } else if (left.length !== right.length) {
-        return false;
-    }
-
-    for (let i = 0; i < left.length; i++) {
-        if (left[i] !== right[i]) {
-            return false;
-        }
-    }
-    return true;
 }
 
 /**

--- a/src/sugarcube-2/validation.ts
+++ b/src/sugarcube-2/validation.ts
@@ -25,6 +25,18 @@ export interface StateInfo {
     passages: Passage[],
 }
 
+/**
+ * An interface for data which could have evaluatable data within it, but might not!
+ * `T`: The type that would result from evaluating it. (Not that we can do that)
+ * `B`: The original type (usually string).
+ */
+export interface Evaluatable<T, B> {
+	original: B,
+	isEvaluated: boolean,
+	value?: T
+}
+
+
 
 /**
  * Simple function for if checking each of two array's elements are equal.
@@ -48,4 +60,69 @@ export function isArrayEqual<T>(left?: T[], right?: T[]): boolean {
         }
     }
     return true;
+}
+
+
+/**
+ * Tries getting the evaluated value of a TwineScript passage name.
+ * Handles literals, and simple TwineScript strings.
+ * @param validPassages 
+ * @param passageName A TwineScript passage name.
+ */
+export function evalPassageId(validPassages: Passage[], passageName: string): Evaluatable<string, string> {
+	// SugarCube simply checks if it is null or if the passage name is valid before returning.
+	// See: SugarCube2 wikifier.js evalPassageId for what we are imitating.
+	if (passageName === "null" || validPassages.find(passage => passage.name === passageName)) {
+		return {
+			original: passageName,
+			isEvaluated: true,
+			value: passageName,
+		}
+	}
+
+	return evaluateTwineScriptString(passageName);
+}
+
+
+/**
+ * Tries evaluating basic TwineScript strings.
+ * This should hopefully be always correct, or at least correct often enough.
+ * (And hopefully in the cases where it isn't correct, SugarCube will choke as well so we have more
+ * of an excuse)
+ * @param code The input TwineScript
+ */
+export function evaluateTwineScriptString(code: string): Evaluatable<string, string> {
+    // Note: If this is moved out of this function for re-use then that exec uses the state held
+    // inside the regexp will have to be taken into account and reset/copy the regex before running.
+    const parseRe = new RegExp([
+        '(""|\'\')',                                          // 1=Empty quotes
+        '("(?:\\\\.|[^"\\\\])+")',                            // 2=Double quoted, non-empty
+        "('(?:\\\\.|[^'\\\\])+')",                            // 3=Single quoted, non-empty
+        '([=+\\-*\\/%<>&\\|\\^~!?:,;\\(\\)\\[\\]{}]+)',       // 4=Operator delimiters
+        '([^"\'=+\\-*\\/%<>&\\|\\^~!?:,;\\(\\)\\[\\]{}\\s]+)' // 5=Barewords
+    ].join('|'), 'g');
+
+    let match;
+
+    while ((match = parseRe.exec(code)) !== null) {
+        if (match[1] === code) { // Empty
+            return {
+                original: code,
+                isEvaluated: true,
+                value: "",
+            };
+        } else if (match[2] === code || match[3] === code) {
+            return {
+                original: code,
+                isEvaluated: true,
+                // Remove quotes
+                value: code.slice(1, -1),
+            }
+        }
+    }
+
+    return {
+        original: code,
+        isEvaluated: false,
+    }
 }

--- a/src/sugarcube-2/validation.ts
+++ b/src/sugarcube-2/validation.ts
@@ -1,0 +1,51 @@
+/*
+    This file is for utilities relating to the validation/checking/correction of various parts of the code.
+        Such as: Arguments, Parameters, Passages, and so on.
+*/
+
+import { Passage } from "../tree-view";
+
+
+// The warning class is for things that are technically 'errors' (in that they are invalid)
+// but are likely just slightly incorrect and so should be counted as at least a partial validity
+// (Ex: Passing a link with a setter to something that takes `linkNoSetter`)
+// Could in the future provide quick fixes?
+export class Warning {
+    readonly message: string;
+
+    constructor(message: string) {
+        this.message = message;
+    }
+}
+
+/**
+ * Information about the state, used for verifying some parts of the arguments and parameters.
+ */
+export interface StateInfo {
+    passages: Passage[],
+}
+
+
+/**
+ * Simple function for if checking each of two array's elements are equal.
+ * Uses triple-equals and does not do any recursive calls on sub-arrays.
+ * Has the option to take undefined arrays, because that is just better for the place it is used in.
+ */
+export function isArrayEqual<T>(left?: T[], right?: T[]): boolean {
+    if (left === right) {
+        // They're the same array, or both undefined
+        return true;
+    } else if (left === undefined || right === undefined) {
+        // We already checked for equality, so if either are undefined then we know it isn't equal
+        return false;
+    } else if (left.length !== right.length) {
+        return false;
+    }
+
+    for (let i = 0; i < left.length; i++) {
+        if (left[i] !== right[i]) {
+            return false;
+        }
+    }
+    return true;
+}


### PR DESCRIPTION
This pull-request validates passages used in these places:
 - Argument links/images.  
 - Parameters that take passage names. (Such as `<<link text passage>><</link>>`)  
This does *not* cover normal in-text links, only handling those passed in through arguments to a macro.  
This is a Warning rather than an error because having incomplete paths through a story is not uncommon, and thus is intended at times.  
![2021-01-15-192546_821x446_scrot](https://user-images.githubusercontent.com/13157904/104793594-61489600-5771-11eb-87b4-71ab198f40cf.png)
The images showcases where it currently succeeds at.  
You may notice the `window.garbage` and the `[[garbage]]` link part. This is a necessary false-positive for the common use-case. Since the input to the link can be arbitrary TwineScript (thus translated to JavaScript..), we can not 100% validate whether or not it is meant to be a passage name or a TwineScript string. (We *can* validate whether it is a passage name, because of SugarCube just using the given value as the passage name if it exists then validating it, but we're trying to provide warnings about invalid ones).
So to support the *really* common case of doing `[[MyPassageName]]` over `[[MyGlobalVariable]]`, this treats single Barewords as if they were intended to be passage names. As shown in the image that would result in a false-positive in that case. There is a setting to disable the single Bareword being treated as if it is meant to be a passage name, for if a user is doing something strange.  
As well, mentioned by the link beneath that, it does not currently handle `[[Oh My]]`, where it is meant to be a passage name to a passage with a space in it. The single bareword handling somewhat just falls out of the basic Twinescript conversion regex from SugarCube, but handling space separated would be somewhat more complex and so is not done in this Pull Request.
The PR is broken into smaller commits, of which they are not the most sensibly ordered, but all build up to the PR.  
  
A future goal would be to extend this to inline passage name validation, but I have no clue how challenging extracting the links from the documents would/will be.