### PR TITLE
Cache collect; Collect performance improvements

### DIFF
--- a/src/sugarcube-2/code-actions.ts
+++ b/src/sugarcube-2/code-actions.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as yaml from 'yaml';
-import { macroRegex, macroDef, macro, collect } from './macros';
+import { macroRegex, macroDef, macro, collectCache } from './macros';
 
 export class EndMacro implements vscode.CodeActionProvider {
 	public static readonly providedCodeActionKinds = [
@@ -28,7 +28,7 @@ export class Unrecognized implements vscode.CodeActionProvider {
 	];
 
 	public async provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext): Promise<vscode.CodeAction[]> {
-		const collected = await collect(document.getText());
+		const collected = await collectCache.get(document);
 		let newMacros = new Map<string, macroDef>();
 
 		context.diagnostics


### PR DESCRIPTION
This pull-request performs two optimizations for `collect`. It was worked on @Goctionni and myself.
- Caching: The first commit does some basic caching for files. Using their path as the cache key. Uses `vscode.TextDocument`'s `version` field to keep track if it should update. This isn't the most efficient it could be, as this will do a full `collect` whenever the document is updated even a minor amount. So now it will only collect a file once rather than everytime you even click on it.
    - The third commit makes this store the promise rather than the result. This stops multiple calls from event listeners from occurring and causing multiple evaluations before the first cache. This could be applied to the `macroList` cache as well, since it had that issue, but the main cause of that was `collect`.. and since collect is cached now it doesn't matter as much.
- Collect performance: We worked on collect performance for a while.
    - Moved the cleanedMacros outside of the loop and constructs the regex though. Unsure of how much speed this gained us.
    - Was originally taking 24 *seconds* to collect a single large file. The primary parts of which appeared to be the calculation of the range. We of course couldn't just remove that, and so instead worked to make so they weren't doing large string operations. We managed to replace all of them with simpler calculations. There are probably still improvements that could be made, but this makes it drastically more performant.
Note: The initial collect will take the longest, since it also has to wait for `macroList`. (Which looked slower than I thought it should be, may take a look at that).
Note2: The branch name doesn't make complete sense since I was originally just going to have the cache, but we also did the performance of collect.