### PR TITLE
Fix the isEmpty check

### DIFF
--- a/src/sugarcube-2/parameters.ts
+++ b/src/sugarcube-2/parameters.ts
@@ -294,7 +294,7 @@ export class Parameters {
      * Whether the variants are empty.
      */
     isEmpty(): boolean {
-        return this.variants.some(variant => !variant.isEmpty());
+        return !this.variants.some(variant => !variant.isEmpty());
     }
 }
 /**


### PR DESCRIPTION
The modified isEmpty check was messed up (oops), which would break using an empty parameters list (it wouldn't warn you that you used arguments when it doesn't accept any). This fixed that.