### PR TITLE
Removes handling of image link as a passage name

### DIFF
--- a/src/sugarcube-2/arguments.ts
+++ b/src/sugarcube-2/arguments.ts
@@ -227,7 +227,7 @@ export enum LinkSyntax {
 export interface ImageArgument {
 	type: ArgType.Image,
 	range: vscode.Range,
-	image: Evaluatable<string, string>,
+	image: string,
 	passage?: Evaluatable<string, string>,
 	align?: 'left' | 'right',
 	// TODO: This could be evaluatable
@@ -466,7 +466,9 @@ export function parseArguments(source: UnparsedMacroArguments, lexRange: vscode.
 						let arg: ImageArgument = {
 							type: ArgType.Image,
 							// TODO: should we assume that source is a string?
-							image: checkPassageId(state.passages, markup.source as string, range, args.warnings),
+							// TODO: This can actually be a passage through some Twine 1.4, but
+							// that isn't currently handled. (See SugarCube parserlib.js #691)
+							image: markup.source as string,
 							range,
 						};
 


### PR DESCRIPTION
A slight bug from #17  was that it handled image links as if they were passage names, giving a warning on them.  
This changes that to handle them appropriately (ignoring them).
Note: There is actually a case where the image source as handled as a passage, as mentioned in the comment that was added, Twine 1.4 apparently had some weird image passage feature or something. So, that could be handled in the future, but is likely not used that often.  