### PR TITLE
Fix multiline macro collection

### DIFF
--- a/src/sugarcube-2/macros.ts
+++ b/src/sugarcube-2/macros.ts
@@ -249,7 +249,13 @@ const collectUncached = async function (raw: string): Promise<CollectedMacros> {
 		lineEnd = lineIndices.slice(lineStart)
 			.findIndex((index) => index >= exIndex + ex0Length) + lineStart;
 		const charStart = exIndex - (lineStart ? lineIndices[lineStart - 1] : 0) - 1;
-        const charEnd = charStart + ex0Length;
+		let charEnd = 0;
+		if (lineStart != lineEnd) {
+			// Non-equal lines
+			charEnd = lineIndices[lineEnd] - lineIndices[lineEnd - 1] - 1;
+		} else {
+			charEnd = charStart + ex0Length;
+		}
 
 		let range = new vscode.Range(lineStart, charStart, lineEnd, charEnd);
 


### PR DESCRIPTION
This is a fix for collecting multiline macros.
Previously, it uses the matched macros length to calculate the ending character position, but since vscode separates that based on lines, it would be very incorrect for multiple line macros (Accumulating the previous line lengths, then having that as the ending position off into nowhere).
This fixes that.
Note: This shows that there is a slight issue in argument/parameters errors and warnings not taking into account multiple lines. I have ideas for handling that, and it should not be too challenging, but is not in this PR.