### PR TITLE
Add Command to add all unrecognized macros to definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,6 +371,11 @@
 				"command": "twee3LanguageTools.sc2.clearArgumentCache",
 				"title": "Clear Argument Cache",
 				"category": "Twee3 Language Tools"
+			},
+			{
+				"command": "twee3LanguageTools.sc2.addAllUnrecognizedMacros",
+				"title": "Add All Unrecognized Macros to Definition File",
+				"category": "Twee3 Language Tools"
 			}
 		],
 		"menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -248,6 +248,10 @@ export async function activate(ctx: vscode.ExtensionContext) {
 			sc2m.argumentCache.clear();
 		})
 		,
+		vscode.commands.registerCommand("twee3LanguageTools.sc2.addAllUnrecognizedMacros", async () => {
+			await sc2ca.addAllUnrecognizedMacros();
+		})
+		,
 		vscode.languages.registerCodeActionsProvider("twee3-sugarcube-2", new sc2ca.EndMacro(), {
 			providedCodeActionKinds: sc2ca.EndMacro.providedCodeActionKinds
 		})


### PR DESCRIPTION
Adds a command to quickly grab all unrecognized macros (from files that have diagnostics, so it could be limited by some scanning limitation, but that seems fine) and add them to the definitions. This helps in making the extension easier to use when using it on an existing codebase.