### PR TITLE
Status Bar Addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Manual settings:
 - `twee3LanguageTools.directories.include`: Directories in which to look for twee files. Use glob patterns *relative* to the root of the workspace folders (e.g. `src/unprocessed/twee`, `src/static`, `external`). (Searches the entire workspace by default.)  
 - `twee3LanguageTools.directories.exclude`: Directories to exclude from the search of twee files. Use *absolute* glob patterns (e.g. `**/src/processed/**`). (Excludes `**/node_modules/**` by default.) If passage listing is active, excluded files will not be scanned for passages. They also will not be scanned for errors until manually opened.  
 ⠀
-- `twee3LanguageTools.storyMap.unusedPortClosingDelay`: Duration in milliseconds before the story-map server port is closed after the UI in the browser window has been closed. (`5000` by default.)
+- `twee3LanguageTools.storyMap.unusedPortClosingDelay`: Duration in milliseconds before the Story Map server port is closed after the UI in the browser window has been closed. (`5000` by default.)
 ⠀
 - `twee3LanguageTools.passage.list`: Display list of passages with quick 'jump' links? (`false` by default.)  
 - `twee3LanguageTools.passage.group`: Group passages by? (`None` by default. Can be grouped by file of origin, folder of origin, or passage tags.)  

--- a/package.json
+++ b/package.json
@@ -281,7 +281,12 @@
 				"twee3LanguageTools.storyMap.unusedPortClosingDelay": {
 					"type": "integer",
 					"default": 5000,
-					"markdownDescription": "Duration in milliseconds before the story-map server port is closed after the UI in the browser window has been closed."
+					"markdownDescription": "Duration in milliseconds before the Story Map server port is closed after the UI in the browser window has been closed."
+				},
+				"twee3LanguageTools.passageCounter.openStoryMapWithoutConfirmation": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Disables prompt for opening Story Map by clicking the passage counter in the status bar."
 				}
 			}
 		},
@@ -312,7 +317,8 @@
 		"commands": [
 			{
 				"command": "twee3LanguageTools.storyMap.show",
-				"title": "Show Story-map",
+				"title": "Show Story Map",
+				"category": "Twee3 Language Tools",
 				"icon": {
 					"dark": "res/dark/storyMapTurnOn.svg",
 					"light": "res/light/storyMapTurnOn.svg"
@@ -320,7 +326,7 @@
 			},
 			{
 				"command": "twee3LanguageTools.storyMap.stop",
-				"title": "Stop Story-map server",
+				"title": "Stop Story Map server",
 				"icon": {
 					"dark": "res/dark/storyMapTurnOff.svg",
 					"light": "res/light/storyMapTurnOff.svg"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,9 @@ import { PassageListProvider, Passage, jumpToPassage } from './passage';
 import * as sc2m from './sugarcube-2/macros';
 import * as sc2ca from './sugarcube-2/code-actions';
 import { packer } from './story-map/packer';
+
+import { passageCounter } from './status-bar'
+import { sbStoryMapConfirmationDialog } from './status-bar';
 //#endregion
 
 const documentSelector: vscode.DocumentSelector = {
@@ -24,6 +27,9 @@ const documentSelector: vscode.DocumentSelector = {
 
 export async function activate(ctx: vscode.ExtensionContext) {
 	vscode.commands.executeCommand('setContext', 't3lt.extensionActive', true);
+
+	const sbPassageCounter = passageCounter(ctx);
+
 
 	const passageListProvider = new PassageListProvider(ctx);
 	const collection = vscode.languages.createDiagnosticCollection();
@@ -45,6 +51,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
 			tweeProjectConfig(ctx, doc);
 			updateDiagnostics(ctx, doc, collection);
 			await parseText(ctx, doc);
+			passageCounter(ctx, sbPassageCounter);
 			if (vscode.workspace.getConfiguration("twee3LanguageTools.passage").get("list")) passageListProvider.refresh();
 		})
 	}
@@ -66,7 +73,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
 	const mapStopCommand = vscode.commands.registerCommand("twee3LanguageTools.storyMap.stop", stopUIWrapper);
 
 	ctx.subscriptions.push(
-		mapShowCommand, mapStopCommand,
+		mapShowCommand, mapStopCommand, sbPassageCounter,
 		vscode.languages.registerDocumentSemanticTokensProvider(documentSelector, new DocumentSemanticTokensProvider(ctx), legend)
 		,
 		vscode.languages.registerHoverProvider(documentSelector, {
@@ -188,6 +195,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
 			await parseText(ctx, document);
 			if (vscode.workspace.getConfiguration("twee3LanguageTools.passage").get("list")) passageListProvider.refresh();
 			if (storyMap.client) sendPassageDataToClient(ctx, storyMap.client);
+			passageCounter(ctx, sbPassageCounter);
 		})
 		,
 		vscode.window.registerTreeDataProvider(
@@ -259,5 +267,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
 		vscode.languages.registerCodeActionsProvider("twee3-sugarcube-2", new sc2ca.Unrecognized(), {
 			providedCodeActionKinds: sc2ca.Unrecognized.providedCodeActionKinds
 		})
+		,
+		vscode.commands.registerCommand("twee3LanguageTools.passageCounter.clickCheck", sbStoryMapConfirmationDialog)
 	);
 };

--- a/src/status-bar.ts
+++ b/src/status-bar.ts
@@ -1,0 +1,44 @@
+import * as vscode from "vscode";
+import { Passage } from "./passage";
+import { parseRawText } from "./parse-text"
+
+export function passageCounter(ctx: vscode.ExtensionContext, StatusBarItem?: vscode.StatusBarItem) {
+  const passages = ctx.workspaceState.get("passages", []) as Passage[];
+  let specCount = 0;
+  for (let i = 0;i < passages.length;i++) {
+    if (passages[i].tags?.includes("script") || passages[i].tags?.includes("stylesheet") || ["PassageDone", "PassageFooter", "PassageHeader", "PassageReady", "StoryAuthor", "StoryBanner", "StoryCaption", "StoryDisplayTitle", "StoryInit", "StoryInterface", "StoryMenu", "StorySettings", "StoryShare", "StorySubtitle", "StoryTitle", "StoryData",].includes(passages[i].name)) {
+      specCount ++;
+    }
+  };
+  if (!StatusBarItem) {
+    StatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+  };
+  StatusBarItem.text = `Passage Count: ${passages.length}`;
+  StatusBarItem.tooltip = `Total Number of Passages in Twee files: ${passages.length}\nNumber of Story Passages: ${passages.length - specCount}\nClick to open Story Map`;
+  StatusBarItem.command = "twee3LanguageTools.passageCounter.clickCheck"
+  if (passages.length != 0) {
+    StatusBarItem.show();
+  } else {
+    StatusBarItem.hide();
+  }
+  return StatusBarItem;
+  
+};
+
+export async function sbStoryMapConfirmationDialog() {
+    const settings = vscode.workspace.getConfiguration("twee3LanguageTools.passageCounter");
+    const confirmation = settings.get("openStoryMapWithoutConfirmation");
+    if (confirmation) {
+        vscode.commands.executeCommand("twee3LanguageTools.storyMap.show");
+    } else {
+      const answer = await vscode.window.showInformationMessage(
+        "Would you like to open the Story Map?\n(Opens in default external browser)",
+        { modal: true },
+        "Open This Time", "Always Open"
+      );
+        switch (answer) {
+            case "Always Open": settings.update("openStoryMapWithoutConfirmation", true);
+            case "Open This Time": vscode.commands.executeCommand("twee3LanguageTools.storyMap.show");
+        }
+    }
+}


### PR DESCRIPTION
Adds Status Bar to extension.
Status bar object shows current number of passages on label, and shows additional information on hover, such as the number of "story passages" in the workspace.
Clicking on status bar object will prompt to open the Story Map feature in external browser, with option to prevent future prompts.

Also included in PR are small wording changes to README file and package.json, as well as new extension setting for Story Map prompt.