### PR TITLE
Add receiver parameter type

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -129,6 +129,7 @@ There are a number of parameter types:
 - `string`: A quoted string. You may want to use `text` instead. Ex: ``
 - `text`: Arbitrary text, quoted or not. Includes much of the above (except for links/images). Ex: `<<ex test>>` (text: `test`), `<<ex "lorem ipsum">>` (text: `lorem ipsum`), `<<ex 24.9>>` (text: `24.9`).
 - `passage`: A passage name. (Note: Not currently verified to be valid).
+- `receiver`: The name of a SugarCube variable as a string. Such as `<<textbox "$name">>`, where it writes the value to the variable `$name`.
 There are more proposed parameter types that may be implemented at a future data, if you have suggestions for useful types, please open an issue on the Github repository.
 
 #### Parameter Types Warning

--- a/src/sugarcube-2/macros.json
+++ b/src/sugarcube-2/macros.json
@@ -159,7 +159,7 @@
 		"name": "checkbox",
 		"description": "Creates a checkbox, used to modify the value of the variable with the given name.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<checkbox receiverName uncheckedValue checkedValue [autocheck|checked]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-checkbox)",
 		"parameters": [
-			"text &+ bool|text|null|undefined|number|NaN &+ bool|text|null|undefined|number|NaN |+ 'autocheck'|'checked'"
+			"receiver &+ bool|text|null|undefined|number|NaN &+ bool|text|null|undefined|number|NaN |+ 'autocheck'|'checked'"
 		]
 	},
 	"cycle": {
@@ -171,7 +171,7 @@
 		"container": true,
 		"description": "Creates a cycling link, used to modify the value of the variable with the given name. The cycling options are populated via `<<option>>` and/or `<<optionsfrom>>`.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<cycle receiverName [autoselect]>>\n\t[<<option label [value [selected]]>> …]\n\t[<<optionsfrom collection>> …]\n<</cycle>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-cycle)",
 		"parameters": [
-			"text |+ 'autoselect'"
+			"receiver |+ 'autoselect'"
 		]
 	},
 	"option": {
@@ -236,37 +236,37 @@
 		"container": true,
 		"description": "Creates a listbox, used to modify the value of the variable with the given name. The list options are populated via `<<option>>` and/or `<<optionsfrom>>`.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<listbox receiverName [autoselect]>>\n\t[<<option label [value [selected]]>> …]\n\t[<<optionsfrom collection>> …]\n<</listbox>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-listbox)",
 		"parameters": [
-			"text |+ 'autoselect'"
+			"receiver |+ 'autoselect'"
 		]
 	},
 	"numberbox": {
 		"name": "numberbox",
 		"description": "Creates a number input box, used to modify the value of the variable with the given name, optionally forwarding the player to another passage.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<numberbox receiverName defaultValue [passage] [autofocus]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-numberbox)",
 		"parameters": [
-			"text &+ number |+ 'autofocus'",
-			"text &+ number |+ passage|linkNoSetter |+ 'autofocus'"
+			"receiver &+ number |+ 'autofocus'",
+			"receiver &+ number |+ passage|linkNoSetter |+ 'autofocus'"
 		]
 	},
 	"radiobutton": {
 		"name": "radiobutton",
 		"description": "Creates a radio button, used to modify the value of the variable with the given name. Multiple `<<radiobutton>>` macros may be set up to modify the same variable, which makes them part of a radio button group.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<radiobutton receiverName checkedValue [autocheck|checked]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-radiobutton)",
 		"parameters": [
-			"text &+ bool|number|text|null|undefined|NaN |+ 'autocheck'|'checked'"
+			"receiver &+ bool|number|text|null|undefined|NaN |+ 'autocheck'|'checked'"
 		]
 	},
 	"textarea": {
 		"name": "textarea",
 		"description": "Creates a multiline text input block, used to modify the value of the variable with the given name.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<textarea receiverName defaultValue [autofocus]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-textarea)",
 		"parameters": [
-			"text &+ text |+ 'autofocus'"
+			"receiver &+ text |+ 'autofocus'"
 		]
 	},
 	"textbox": {
 		"name": "textbox",
 		"description": "Creates a text input box, used to modify the value of the variable with the given name, optionally forwarding the player to another passage.\n\nSEE: [Interactive macro warning](https://www.motoslave.net/sugarcube/2/docs/#macros-interactive-warning)\n\nUsage:\n\n```\n<<textbox receiverName defaultValue [passage] [autofocus]>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-textbox)",
 		"parameters": [
-			"text &+ text |+ 'autofocus'",
-			"text &+ text |+ passage|linkNoSetter |+ 'autofocus'"
+			"receiver &+ text |+ 'autofocus'",
+			"receiver &+ text |+ passage|linkNoSetter |+ 'autofocus'"
 		]
 	},
 	

--- a/src/sugarcube-2/parameters.ts
+++ b/src/sugarcube-2/parameters.ts
@@ -58,6 +58,29 @@ export const parameterTypes: ParameterType[] = [
     // This allows so many because they could all be turned-into/considered text.
     makeSimpleParameterType("text", "Argument is not text", t => t === ArgType.Bareword || t === ArgType.String || t === ArgType.True || t === ArgType.False || t === ArgType.Null || t === ArgType.NaN || t === ArgType.Number),
     {
+        name: ["receiver"],
+        validate(info: ArgumentInfo): Error | Warning | null {
+            if (info.arg.type === ArgType.String) {
+                let text = info.arg.text;
+                if (text[0] === "_" || text[0] === "$") {
+                    if (text.length === 1) {
+                        return new Error("Variable receiver had sigil but did not have an actual name");
+                    } else {
+                        return null;
+                    }
+                } else {
+                    // TODO: We could maybe have a quick-fix for this.
+                    return new Error("Text given to variable receiver did not have a sigil. Did you mean to write $" + text + " or _" + text + "?");
+                }
+            } else if (info.arg.type === ArgType.Expression || info.arg.type === ArgType.SettingsSetupAccess || info.arg.type === ArgType.Variable) {
+                // We just have to assume that they're correct
+                return null;
+            } else {
+                return new Error("Argument is not a potentially valid variable receiver");
+            }
+        }
+    },
+    {
         name: ["linkNoSetter"],
         validate(info: ArgumentInfo): Error | Warning | null {
             if (info.arg.type !== ArgType.Link) {


### PR DESCRIPTION
Closes #63 
This adds a new parameter type named `receiver` for macros that take in a variable by name, specifically a sugarcube variable of the form `$name` or `_name`. As well, it makes several macros use this type instead, given that their implementation would error at runtime (ex: https://github.com/tmedwards/sugarcube-2/blob/master/src/macros/macrolib.js#L1685 ) if it was not a valid variable.  
![2021-12-25-211551_1095x111_scrot](https://user-images.githubusercontent.com/13157904/147398130-fcfc5727-0c2c-42fc-ab9b-41c1bb54df67.png)
This only detects invalid string literals, as in the above, where you miss the sigil.
Currently this does not supply a quick-fix, since it is a simple fix.

It would be nice to detect the usage of `$name` there, since that is likely a common mistake, but that could also be holding the name of a variable in a variable, which is certainly done in various projects. I might add an off-by-default warning for this, since I rarely do it. If there was a good alternative way of writing what you wanted more explicitly then that would be something to push users towards, but I can't think of a great one.