### PR TITLE
Add support with keybind for toggling bold/italics in SugarCube and Harlowe

### DIFF
--- a/package.json
+++ b/package.json
@@ -383,6 +383,14 @@
 				"command": "twee3LanguageTools.sc2.addAllUnrecognizedMacros",
 				"title": "Add All Unrecognized Macros to Definition File",
 				"category": "Twee3 Language Tools"
+			},
+			{
+				"command": "twee3LanguageTools.toggleItalics",
+				"title": "Toggles italics wherever the cursor is"
+			},
+			{
+				"command": "twee3LanguageTools.toggleBold",
+				"title": "Toggles boldness wherever the cursor is"
 			}
 		],
 		"menus": {
@@ -426,7 +434,19 @@
 					"group": "inline"
 				}
 			]
-		}
+		},
+		"keybindings": [
+			{
+				"key": "ctrl+i",
+				"command": "twee3LanguageTools.toggleItalics",
+				"when": "editorTextFocus && !editorReadonly"
+			},
+			{
+				"key": "ctrl+b",
+				"command": "twee3LanguageTools.toggleBold",
+				"when": "editorTextFocus && !editorReadOnly"
+			}
+		]
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.9",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,8 @@ import { fileGlob } from './file-ops';
 
 import { PassageListProvider, Passage, jumpToPassage } from './passage';
 
+import * as formatting from "./formatting";
+
 import * as sc2m from './sugarcube-2/macros';
 import * as sc2ca from './sugarcube-2/code-actions';
 import { packer } from './story-map/packer';
@@ -267,6 +269,28 @@ export async function activate(ctx: vscode.ExtensionContext) {
 		,
 		vscode.commands.registerCommand("twee3LanguageTools.sc2.addAllUnrecognizedMacros", async () => {
 			await sc2ca.addAllUnrecognizedMacros();
+		})
+		,
+		// TODO: Allow configuration for which version Harlowe should use since it supports both ''
+		// and ** for bold, and // and * for italics
+		vscode.commands.registerTextEditorCommand("twee3LanguageTools.toggleItalics", editor => {
+			let languageId = editor.document.languageId;
+			if (languageId === "twee3-sugarcube-2") {
+				formatting.styleByWrapping(editor, "//");
+			} else if (languageId === "twee3-harlowe-3") {
+				formatting.styleByWrapping(editor, "*");
+			}
+			// TODO: Other story format support
+		})
+		,
+		vscode.commands.registerTextEditorCommand("twee3LanguageTools.toggleBold", (editor, edit) => {
+			let languageId = editor.document.languageId;
+			if (languageId === "twee3-sugarcube-2") {
+				formatting.styleByWrapping(editor, "''");
+			}  else if (languageId === "twee3-harlowe-3") {
+				formatting.styleByWrapping(editor, "**");
+			}
+			// TODO: Other story format support
 		})
 		,
 		vscode.languages.registerCodeActionsProvider("twee3-sugarcube-2", new sc2ca.EndMacro(), {

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -1,0 +1,158 @@
+
+// The majority of this is from https://github.com/yzhang-gh/vscode-markdown/blob/2043c1b99541e4cc5734c6fc88714865d11a161a/src/formatting.ts
+
+import { Position, Range, Selection, TextEditor, window, workspace, WorkspaceEdit } from "vscode";
+
+export function styleByWrapping(editor: TextEditor, startPattern: string, endPattern = startPattern) {
+    let selections = editor.selections;
+
+    let batchEdit = new WorkspaceEdit();
+    let shifts: [Position, number][] = [];
+    let newSelections: Selection[] = selections.slice();
+
+    for (const [i, selection] of selections.entries()) {
+
+        let cursorPos = selection.active;
+        const shift = shifts.map(([pos, s]) => (selection.start.line == pos.line && selection.start.character >= pos.character) ? s : 0)
+            .reduce((a, b) => a + b, 0);
+
+        if (selection.isEmpty) {
+            const context = getContext(editor, cursorPos, startPattern, endPattern);
+
+            // Patterns are added for SugarCube
+            // No selected text
+            if (
+                startPattern === endPattern &&
+                ["**", "*", "__", "_", "//", "''"].includes(startPattern) &&
+                context === `${startPattern}text|${endPattern}`
+            ) {
+                // `**text|**` to `**text**|`
+                let newCursorPos = cursorPos.with({ character: cursorPos.character + shift + endPattern.length });
+                newSelections[i] = new Selection(newCursorPos, newCursorPos);
+                continue;
+            } else if (context === `${startPattern}|${endPattern}`) {
+                // `**|**` to `|`
+                let start = cursorPos.with({ character: cursorPos.character - startPattern.length });
+                let end = cursorPos.with({ character: cursorPos.character + endPattern.length });
+                wrapRange(editor, batchEdit, shifts, newSelections, i, shift, cursorPos, new Range(start, end), false, startPattern, endPattern);
+            } else {
+                // Select word under cursor
+                // The markdown extension uses a custom regex very similar to this one for their def
+                // of word. This removes the exclusion of certain characters since formats use them.
+                let wordRange = editor.document.getWordRangeAtPosition(cursorPos, /(-?\d*\.\d\w*)|([^\!\@\#\%\^\&\(\)\-\=\+\[\{\]\}\\\|\;\:\"\,\.\<\>\?\s\，\。\《\》\？\；\：\‘\“\’\”\（\）\【\】\、]+)/g);
+                if (wordRange == undefined) {
+                    wordRange = selection;
+                }
+                // One special case: toggle strikethrough in task list
+                const currentTextLine = editor.document.lineAt(cursorPos.line);
+                if (startPattern === '~~' && /^\s*[\*\+\-] (\[[ x]\] )? */g.test(currentTextLine.text)) {
+                    let match = currentTextLine.text.match(/^\s*[\*\+\-] (\[[ x]\] )? */g) as RegExpMatchArray;
+                    wordRange = currentTextLine.range.with(new Position(cursorPos.line, match[0].length));
+                }
+                wrapRange(editor, batchEdit, shifts, newSelections, i, shift, cursorPos, wordRange, false, startPattern, endPattern);
+            }
+        } else {
+            // Text selected
+            wrapRange(editor, batchEdit, shifts, newSelections, i, shift, cursorPos, selection, true, startPattern, endPattern);
+        }
+    }
+
+    return workspace.applyEdit(batchEdit).then(() => {
+        editor.selections = newSelections;
+    });
+}
+
+/**
+ * Add or remove `startPattern`/`endPattern` according to the context
+ * @param editor
+ * @param options The undo/redo behavior
+ * @param cursor cursor position
+ * @param range range to be replaced
+ * @param isSelected is this range selected
+ * @param startPtn
+ * @param endPtn
+ */
+function wrapRange(editor: TextEditor, wsEdit: WorkspaceEdit, shifts: [Position, number][], newSelections: Selection[], i: number, shift: number, cursor: Position, range: Range, isSelected: boolean, startPtn: string, endPtn: string) {
+    let text = editor.document.getText(range);
+    const prevSelection = newSelections[i];
+    const ptnLength = (startPtn + endPtn).length;
+
+    let newCursorPos = cursor.with({ character: cursor.character + shift });
+    let newSelection: Selection;
+    if (isWrapped(text, startPtn, endPtn)) {
+        // remove start/end patterns from range
+        wsEdit.replace(editor.document.uri, range, text.substr(startPtn.length, text.length - ptnLength));
+
+        shifts.push([range.end, -ptnLength]);
+
+        // Fix cursor position
+        if (!isSelected) {
+            if (!range.isEmpty) { // means quick styling
+                if (cursor.character == range.end.character) {
+                    newCursorPos = cursor.with({ character: cursor.character + shift - ptnLength });
+                } else {
+                    newCursorPos = cursor.with({ character: cursor.character + shift - startPtn.length });
+                }
+            } else { // means `**|**` -> `|`
+                newCursorPos = cursor.with({ character: cursor.character + shift + startPtn.length });
+            }
+            newSelection = new Selection(newCursorPos, newCursorPos);
+        } else {
+            newSelection = new Selection(
+                prevSelection.start.with({ character: prevSelection.start.character + shift }),
+                prevSelection.end.with({ character: prevSelection.end.character + shift - ptnLength })
+            );
+        }
+    } else {
+        // add start/end patterns around range
+        wsEdit.replace(editor.document.uri, range, startPtn + text + endPtn);
+
+        shifts.push([range.end, ptnLength]);
+
+        // Fix cursor position
+        if (!isSelected) {
+            if (!range.isEmpty) { // means quick styling
+                if (cursor.character == range.end.character) {
+                    newCursorPos = cursor.with({ character: cursor.character + shift + ptnLength });
+                } else {
+                    newCursorPos = cursor.with({ character: cursor.character + shift + startPtn.length });
+                }
+            } else { // means `|` -> `**|**`
+                newCursorPos = cursor.with({ character: cursor.character + shift + startPtn.length });
+            }
+            newSelection = new Selection(newCursorPos, newCursorPos);
+        } else {
+            newSelection = new Selection(
+                prevSelection.start.with({ character: prevSelection.start.character + shift }),
+                prevSelection.end.with({ character: prevSelection.end.character + shift + ptnLength })
+            );
+        }
+    }
+
+    newSelections[i] = newSelection;
+}
+
+function isWrapped(text: string, startPattern: string, endPattern: string): boolean {
+    return text.startsWith(startPattern) && text.endsWith(endPattern);
+}
+
+function getContext(editor: TextEditor, cursorPos: Position, startPattern: string, endPattern: string): string {
+    let startPositionCharacter = cursorPos.character - startPattern.length;
+    let endPositionCharacter = cursorPos.character + endPattern.length;
+
+    if (startPositionCharacter < 0) {
+        startPositionCharacter = 0;
+    }
+
+    let leftText = editor.document.getText(new Range(cursorPos.line, startPositionCharacter, cursorPos.line, cursorPos.character));
+    let rightText = editor.document.getText(new Range(cursorPos.line, cursorPos.character, cursorPos.line, endPositionCharacter));
+
+    if (rightText == endPattern) {
+        if (leftText == startPattern) {
+            return `${startPattern}|${endPattern}`;
+        } else {
+            return `${startPattern}text|${endPattern}`;
+        }
+    }
+    return '|';
+}


### PR DESCRIPTION
This adds a default keybind (which users can unbind/rebind through VSCode's inbuilt keyboard shortcut handling) to add the appropriate symbols surrounding their words. Currently it has support for SugarCube and Harlowe, but adding others should be easy.
There is potential for improvement in allowing the user to configure what symbol to use, since SugarCube allows the usage of html and they might want `<i>text</i>` instead, and Harlowe supports multiple syntaxes for italics/bold.  
This can also probably be expanded to a keybind for strikethrough and underline, but there is likely less need for such.  
The majority of the code that handles this is from https://github.com/yzhang-gh/vscode-markdown/blob/2043c1b99541e4cc5734c6fc88714865d11a161a/src/formatting.ts#L308 which already handles a lot of the edge cases and complexity. It being MIT licensed lets the part be included without issue.  
There are some modifications to the code to support the specifics of Twine.

![Peek 2021-12-26 00-50](https://user-images.githubusercontent.com/13157904/147401381-f39b901f-198e-4958-8fff-7672ab14a3bb.gif)

