### PR TITLE
Add the ability to declare decorations for macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The following properties are currently programmed, even though not all of them a
 - **deprecated** `(boolean)` *optional*: If the macro is deprecated or not. `false` by default.
 - **deprecatedSuggestions** `(string array)` *optional*: If the macro is deprecated, specify any alternatives to the macro as an array.
 - **parameters** `(object)` *optional*: Allows for macro argument validation. [Read here](docs/parameters.md) for more information.
+- **decoration** `(object)` *optional*: Allows for declaring decorations to be displayed on that macro. Uses [DecorationRenderOptions](https://code.visualstudio.com/api/references/vscode-api#DecorationRenderOptions)' fields. Requires `definedMacroDecorations` setting to be enabled.
 
 **NOTE:** Multiple `twee-config` files can be present in a workspace. They will stack and add to the macro definitions for the workspace. The recommended strategy is to make separate files for separate macro sets/libraries, e.g. (the following file can also be used as an example):
 - `click-to-proceed.twee-config.yaml` ([Link](https://github.com/cyrusfirheir/cycy-wrote-custom-macros/blob/master/click-to-proceed/click-to-proceed.twee-config.yaml))
@@ -178,6 +179,7 @@ Manual settings:
 - `twee3LanguageTools.twee-3.error.storyData.format`: Throw an error when missing the story format field (`format`) in `StoryData` special passage? (`true` by default.)  
 - `twee3LanguageTools.twee-3.error.storyData.formatVersion`: Throw an error when missing the story format version field (`format-version`) in `StoryData` special passage? (`true` by default.)  
 ⠀
+- `twee3LanguageTools.sugarcube-2.definedMacroDecorations`: Whether to use the decorations field in macro definitions. (`false` by default.)
 - `twee3LanguageTools.sugarcube-2.warning.undefinedMacro`: Warn about macros/widgets which were not found in definitions (`*.twee-config.yaml` or `*.twee-config.json` files) or the core SugarCube macro library? (`true` by default.)  
 - `twee3LanguageTools.sugarcube-2.warning.deprecatedMacro`: Warn about deprecated macros/widgets? (`true` by default.)  
 - `twee3LanguageTools.sugarcube-2.warning.endMacro`: Warn about the deprecated `<<end...>>` closing tag syntax? (`true` by default.)  

--- a/package.json
+++ b/package.json
@@ -268,6 +268,11 @@
 					"default": true,
 					"markdownDescription": "Provide errors about invalid parameter types being passed into macros? Requires `argumentParsing` to be on."
 				},
+				"twee3LanguageTools.sugarcube-2.definedMacroDecorations": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "If a macro has a decoration defined for it, it will be displayed when seen in a file."
+				},
 				"twee3LanguageTools.experimental.sugarcube-2.selfClosingMacros.enable": {
 					"type": "boolean",
 					"default": false,

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -1,0 +1,20 @@
+import * as vscode from 'vscode';
+
+import * as sc2 from './sugarcube-2/macros';
+
+export const updateDecorations = async function(ctx: vscode.ExtensionContext, editor: vscode.TextEditor) {
+	if (editor.document.languageId === "twee3-sugarcube-2") {
+		await sc2.updateDecorations(ctx, editor);
+	}
+}
+
+export const clearDecorations = async function(ctx: vscode.ExtensionContext, editor: vscode.TextEditor) {
+    if (editor.document.languageId === "twee3-sugarcube-2") {
+        await sc2.clearDecorations(ctx, editor);
+    }
+}
+
+/// This function is used when we do not know which specific editor changed.
+export const updateTextEditorDecorations = function(ctx: vscode.ExtensionContext) {
+	return Promise.all(vscode.window.visibleTextEditors.map(editor => updateDecorations(ctx, editor)));
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import { packer } from './story-map/packer';
 
 import { passageCounter } from './status-bar'
 import { sbStoryMapConfirmationDialog } from './status-bar';
+import { updateDecorations, updateTextEditorDecorations } from './decorations';
 //#endregion
 
 const documentSelector: vscode.DocumentSelector = {
@@ -115,6 +116,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
 		vscode.window.onDidChangeActiveTextEditor(editor => {
 			if (editor && /^twee3.*/.test(editor.document.languageId)) {
 				updateDiagnostics(ctx, editor.document, collection);
+				updateDecorations(ctx, editor);
 			}
 		})
 		,
@@ -122,11 +124,13 @@ export async function activate(ctx: vscode.ExtensionContext) {
 			if (!/^twee3.*/.test(document.languageId)) return;
 			await changeStoryFormat(document);
 			updateDiagnostics(ctx, document, collection);
+			updateTextEditorDecorations(ctx);
 		})
 		,
 		vscode.workspace.onDidChangeTextDocument(e => {
 			if (!/^twee3.*/.test(e.document.languageId)) return;
 			updateDiagnostics(ctx, e.document, collection);
+			updateTextEditorDecorations(ctx);
 		})
 		,
 		vscode.workspace.onDidChangeConfiguration(e => {
@@ -155,6 +159,9 @@ export async function activate(ctx: vscode.ExtensionContext) {
 			}
 			if (e.affectsConfiguration("twee3LanguageTools.sugarcube-2.warning.barewordLinkPassageChecking")) {
 				sc2m.argumentCache.clearMacrosUsingPassage();
+			}
+			if (e.affectsConfiguration("twee3LanguageTools.sugarcube-2.definedMacroDecorations")) {
+				updateTextEditorDecorations(ctx);
 			}
 		})
 		,
@@ -279,4 +286,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
 		,
 		vscode.commands.registerCommand("twee3LanguageTools.passageCounter.clickCheck", sbStoryMapConfirmationDialog)
 	);
+
+	// This is needed so that on first load, the active file will get colors.
+	updateTextEditorDecorations(ctx);
 };

--- a/src/sugarcube-2/validation.ts
+++ b/src/sugarcube-2/validation.ts
@@ -70,6 +70,51 @@ export function isArrayEqual<T>(left?: T[], right?: T[]): boolean {
     return true;
 }
 
+/**
+ * Performs a surface level comparison of the fields of the two objects
+ * This is probably less efficient than it should be and perhaps should be replaced with lodash's 
+ * isEqual
+ */
+export function isObjectSimpleEqual(left?: Record<string, any>, right?: Record<string, any>): boolean {
+    if (left === right) {
+        // They're the same object
+        return true;
+    } else if (left === undefined || right === undefined) {
+        return false;
+    }
+
+    let left_keys = Object.keys(left);
+    let right_keys = Object.keys(right);
+
+    if (left_keys.length != right_keys.length) {
+        return false;
+    }
+
+    for (let i = 0; i < left_keys.length; i++) {
+        let key = left_keys[i];
+        if (!(key in right)) {
+            return false;
+        }
+
+        if (left[key] !== right[key]) {
+            return false;
+        }
+    }
+
+    for (let i = 0; i < right_keys.length; i++) {
+        let key = right_keys[i];
+        if (!(key in left)) {
+            return false;
+        }
+
+        if (left[key] !== right[key]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 
 /**
  * Tries getting the evaluated value of a TwineScript passage name.


### PR DESCRIPTION
This lets users declare decorations in the form of https://code.visualstudio.com/api/references/vscode-api#DecorationRenderOptions for usage on macros. This is useful in providing visual distinctions for certain macros, such as for dialogue macros and the like.  
By default this is off, since most users will not use it.  
This does not provide any decorations for the standard macros, since they are very personal preference.