### PR TITLE
Make italics/bold specific to formats to better work when in projects with more than just Twee

### DIFF
--- a/package.json
+++ b/package.json
@@ -444,12 +444,22 @@
 			{
 				"key": "ctrl+i",
 				"command": "twee3LanguageTools.toggleItalics",
-				"when": "editorTextFocus && !editorReadonly"
+				"when": "editorTextFocus && !editorReadOnly && editorLangId == twee3-sugarcube-2"
 			},
 			{
 				"key": "ctrl+b",
 				"command": "twee3LanguageTools.toggleBold",
-				"when": "editorTextFocus && !editorReadOnly"
+				"when": "editorTextFocus && !editorReadOnly && editorLangId == twee3-sugarcube-2"
+			},
+			{
+				"key": "ctrl+i",
+				"command": "twee3LanguageTools.toggleItalics",
+				"when": "editorTextFocus && !editorReadOnly && editorLangId == twee3-harlowe-2"
+			},
+			{
+				"key": "ctrl+b",
+				"command": "twee3LanguageTools.toggleBold",
+				"when": "editorTextFocus && !editorReadOnly && editorLangId == twee3-harlowe-2"
 			}
 		]
 	},


### PR DESCRIPTION
Makes the Ctrl+I and Ctrl+B keybinds for bold and italics specific to story formats in the package.json. This makes so that other keybindings will still work in other files in the same project (such as javascript or markdown).  
This duplicates them because currently the when clauses https://code.visualstudio.com/api/references/when-clause-contexts#conditional-operators don't allow parentheses and so representing it in one entry is probably not possible (unless their binding of operators is weird).