### PR TITLE
Fix bug; Improve adding all macros in files

### DIFF
--- a/package.json
+++ b/package.json
@@ -390,6 +390,11 @@
 				"category": "Twee3 Language Tools"
 			},
 			{
+				"command": "twee3LanguageTools.sc2.addAllUnrecognizedMacrosInFile",
+				"title": "Add All Unrecognized Macros in this file to Definition FIle",
+				"category": "Twee3 Language Tools"
+			},
+			{
 				"command": "twee3LanguageTools.toggleItalics",
 				"title": "Toggles italics wherever the cursor is"
 			},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -278,6 +278,13 @@ export async function activate(ctx: vscode.ExtensionContext) {
 			await sc2ca.addAllUnrecognizedMacros();
 		})
 		,
+		vscode.commands.registerCommand("twee3LanguageTools.sc2.addAllUnrecognizedMacrosInFile", async() => {
+			let editor = vscode.window.activeTextEditor;
+			if (editor) {
+				await sc2ca.addAllUnrecognizedMacrosInCurrentFile(editor.document);
+			}
+		})
+		,
 		// TODO: Allow configuration for which version Harlowe should use since it supports both ''
 		// and ** for bold, and // and * for italics
 		vscode.commands.registerTextEditorCommand("twee3LanguageTools.toggleItalics", editor => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -274,8 +274,8 @@ export async function activate(ctx: vscode.ExtensionContext) {
 			sc2m.argumentCache.clear();
 		})
 		,
-		vscode.commands.registerCommand("twee3LanguageTools.sc2.addAllUnrecognizedMacros", async () => {
-			await sc2ca.addAllUnrecognizedMacros();
+		vscode.commands.registerCommand("twee3LanguageTools.sc2.addAllUnrecognizedMacros", () => {
+			sc2ca.addAllUnrecognizedMacros();
 		})
 		,
 		vscode.commands.registerCommand("twee3LanguageTools.sc2.addAllUnrecognizedMacrosInFile", async() => {

--- a/src/sugarcube-2/code-actions.ts
+++ b/src/sugarcube-2/code-actions.ts
@@ -127,40 +127,80 @@ export const addAllUnrecognizedMacrosInCurrentFile = async (document: vscode.Tex
 // Currently this function has the slight 'issue' that it will take the first definition it thinks 
 // of when finding a macro. This means that if the first usage is a container macro and the later
 // usages aren't, it will think it is a container macro.
-export const addAllUnrecognizedMacros = async () => {
-	// let collected = await collectCache.get(document);
-	const macroDefinitions = await macroList();
-	let allDiags = vscode.languages.getDiagnostics();
-	let uniqueMacros: Record<string, macroDef> = Object.create(null);
-	
-	for (let i = 0; i < allDiags.length; i++) {
-		let path: vscode.Uri = allDiags[i][0];
-		let document: vscode.TextDocument = await vscode.workspace.openTextDocument(path);
-		if (document.languageId !== "twee3-sugarcube-2") {
-			continue;
-		}
+export const addAllUnrecognizedMacros = () => {
+	// TODO: It would be good to make so that you can't start two of these.
 
-		// We don't bother using the diagnostics.
-		let collected = await collectCache.get(document);
-		for (let j = 0; j < collected.macros.length; j++) {
-			let name: MacroName = collected.macros[j].name;
-			let def: macroDef = {
-				name,
-			};
-
-			if (name in uniqueMacros || name in macroDefinitions) {
-				continue;
-			}
-
-			// TODO: This could be made more efficient by just updating the uniqueMacro entry
-			// when we run across another instance of it.
-			if (collected.macros.some(el => el.name == def.name && !el.open)) {
-				def.container = true;
-			}
-
-			uniqueMacros[name] = def;
-		}
+	let storyFormat = vscode.workspace.getConfiguration("twee3LanguageTools.storyformat").get("current");
+	if (storyFormat !== "sugarcube-2") {
+		// We can't just check each document, because vscode just assigns a lot of them 'twee'
+		return;
 	}
 
-	await addMacrosToFile(uniqueMacros);
+	vscode.window.withProgress({
+		location: vscode.ProgressLocation.Notification,
+		cancellable: true,
+		title: 'Adding all unrecognized macros'
+	}, async (progress, token) => {
+		// Show that we're starting to process
+		progress.report({
+			message: "Beginning processing..",
+		});
+
+		const macroDefinitions = await macroList();
+		let allDiags = vscode.languages.getDiagnostics();
+		let uniqueMacros: Record<string, macroDef> = Object.create(null);
+	
+		if (token.isCancellationRequested) {
+			return;
+		}
+
+		// TODO: Can we do better than iterating over all files with diagnostics?
+		for (let i = 0; i < allDiags.length; i++) {
+			// The cancellation's break so that the macros can still be added
+			if (token.isCancellationRequested) {
+				break;
+			}
+			
+			const path: vscode.Uri = allDiags[i][0];
+			progress.report({
+				message: "Opening: " + path.toString(),
+			});
+			const document: vscode.TextDocument = await vscode.workspace.openTextDocument(path);
+
+			progress.report({
+				message: "Processing: " + path.toString(),
+			});
+
+			const collected = await collectCache.get(document);
+
+			if (token.isCancellationRequested) {
+				break;
+			}
+
+			for (let j = 0; j < collected.macros.length; j++) {
+				let name: MacroName = collected.macros[j].name;
+				let def: macroDef = {
+					name,
+				};
+
+				if (name in uniqueMacros || name in macroDefinitions) {
+					continue;
+				}
+
+				// TODO: This could be made more efficient by just updating the uniqueMacro entry
+				// when we run across another instance of it.
+				if (collected.macros.some(el => el.name == def.name && !el.open)) {
+					def.container = true;
+				}
+
+				uniqueMacros[name] = def;
+			}
+		}
+
+		progress.report({
+			message: "Adding macros to definitions..",
+		});
+
+		await addMacrosToFile(uniqueMacros);
+	});
 }

--- a/src/sugarcube-2/macros.ts
+++ b/src/sugarcube-2/macros.ts
@@ -781,6 +781,7 @@ export const updateDecorations = async function (ctx: vscode.ExtensionContext, e
 
 		return {el, def};
 	})
+	.filter(v => v.def !== undefined)
 	.filter(v => v.def.decoration_type !== undefined);
 
 	// This could be cleaner


### PR DESCRIPTION
This does a few things.
 - Fixes `updateDecorations` code which wasn't guarding against `undefined` properly, so it'd spit out errors.
 - Add a command to add all unrecognized macros in the current file. Helpful in large projects, where adding all at once is rather slow, or you only care about the current file.
 - Improves the existing 'add all unrecognized macros' command to have a progress bar which informs the user of what it is doing, and allows cancelling it if it is taking too long. Especially helpful in large projects where that might take a while.