### PR TITLE
Add basic max check for validating children macros such as else

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The following properties are currently programmed, even though not all of them a
 - **description** `(string)` *optional*: Description of macro. Shown on hover. Supports markdown.
 - **container** `(boolean)` *optional*: If the macro is a container (i.e. requires a closing tag) or not. `false` by default.
 - **selfClose** `(boolean)` *optional*: If the macro is a self-closable. Requires macro to be a container first. `false` by default.
-- **children** `(string array)` *optional*: If the macro has children, specify their names as an array (currently unused in code.)
+- **children** `(string array)` *optional*: If the macro has children, specify their names as an array
 - **parents** `(string array)` *optional*: If the macro is a child macro, specify the names of its parents as an array (currently unused in code.)
 - **deprecated** `(boolean)` *optional*: If the macro is deprecated or not. `false` by default.
 - **deprecatedSuggestions** `(string array)` *optional*: If the macro is deprecated, specify any alternatives to the macro as an array.

--- a/package.json
+++ b/package.json
@@ -258,6 +258,11 @@
 					"default": true,
 					"markdownDescription": "Provides warnings for links like `[[passage]]` when `passage` is not a valid passage name. This could cause false positives in cases where you are using a global variable."
 				},
+				"twee3LanguageTools.sugarcube-2.error.childrenValidation": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "Provides errors/warnings about issues with the children of a macro, such as using two else branches in the same if macro."
+				},
 				"twee3LanguageTools.sugarcube-2.error.argumentParsing": {
 					"type": "boolean",
 					"default": true,

--- a/src/sugarcube-2/macros.json
+++ b/src/sugarcube-2/macros.json
@@ -72,7 +72,10 @@
 	"if": {
 		"name": "if",
 		"children": [
-			"else",
+			{
+				"name": "else",
+				"max": 1
+			},
 			"elseif"
 		],
 		"container": true,
@@ -123,7 +126,10 @@
 		"name": "switch",
 		"children": [
 			"case",
-			"default"
+			{
+				"name": "default",
+				"max": 1
+			}
 		],
 		"container": true,
 		"description": "Evaluates the given expression and compares it to the value(s) within its `<<case>>` children. The value(s) within each case are compared to the result of the expression given to the parent `<<switch>>`. Upon a successful match, the matching case will have its contents executed. If no cases match and an optional `<<default>>` case exists, which must be the final case, then its contents will be executed. At most one case will execute.\n\nUsage:\n\n```\n<<switch expression>>\n\t[<<case valueList>> …]\n\t[<<default>> …]\n<</switch>>\n```\n\nREAD: [Documentation](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-switch)",

--- a/src/sugarcube-2/validation.ts
+++ b/src/sugarcube-2/validation.ts
@@ -71,6 +71,28 @@ export function isArrayEqual<T>(left?: T[], right?: T[]): boolean {
 }
 
 /**
+ * Uses `isObjectSimpleEqual` to decide if all the elements in an array are equal
+ */
+export function isArraySimpleObjectsEqual<T>(left?: T[], right?: T[]): boolean {
+    if (left === right) {
+        // They're the same array, or both undefined
+        return true;
+    } else if (left === undefined || right === undefined) {
+        // We already checked for equality, so if either are undefined then we know it isn't equal
+        return false;
+    } else if (left.length !== right.length) {
+        return false;
+    }
+
+    for (let i = 0; i < left.length; i++) {
+        if (!isObjectSimpleEqual(left[i], right[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
  * Performs a surface level comparison of the fields of the two objects
  * This is probably less efficient than it should be and perhaps should be replaced with lodash's 
  * isEqual


### PR DESCRIPTION
This adds the ability to specify the `max` number of variants that a child-macro can appear in a macro, such as `<<else>>` having a maximum of `1` per `<<if>>` macro.  
![image](https://user-images.githubusercontent.com/13157904/150671257-f6a5c484-db87-41b6-8655-34e81cb1e315.png)
Usage in definitions is by specifying an object instead of a string:  
```json
children: ["elseif", {
    "name": "else",
    "max": 1
}]
```
Closes #85 
This could be slightly improved by making it place the diagnostic on the offending child-macros, but I decided not to bother.