### PR TITLE
Add focus passage in map command

### DIFF
--- a/package.json
+++ b/package.json
@@ -343,6 +343,11 @@
 				}
 			},
 			{
+				"command": "twee3LanguageTools.storyMap.focusPassage",
+				"title": "Focus passage in Story Map",
+				"category": "Twee3 Language Tools"
+			},
+			{
 				"command": "twee3LanguageTools.passage.pack",
 				"title": "Pack passages to clusters (Experimental)",
 				"category": "Twee3 Language Tools"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { parseText, DocumentSemanticTokensProvider, legend } from './parse-text'
 import { updateDiagnostics } from './diagnostics';
 import { tweeProjectConfig, changeStoryFormat } from './twee-project';
 
-import { sendPassageDataToClient, toUpdatePassage, updatePassages } from "./story-map/socket";
+import { sendPassageDataToClient, toUpdatePassage, updatePassages, focusPassage } from "./story-map/socket";
 import { startUI, stopUI, storyMapIO } from "./story-map/index";
 
 import { fileGlob } from './file-ops';
@@ -284,6 +284,8 @@ export async function activate(ctx: vscode.ExtensionContext) {
 				await sc2ca.addAllUnrecognizedMacrosInCurrentFile(editor.document);
 			}
 		})
+		,
+		vscode.commands.registerTextEditorCommand("twee3LanguageTools.storyMap.focusPassage", (editor) => focusPassage(ctx, storyMap, editor))
 		,
 		// TODO: Allow configuration for which version Harlowe should use since it supports both ''
 		// and ** for bold, and // and * for italics

--- a/src/story-map/socket.ts
+++ b/src/story-map/socket.ts
@@ -5,6 +5,7 @@ import * as socketio from "socket.io";
 import { Passage, PassageRange, PassageStringRange } from "../passage";
 import { readFile, writeFile } from "../file-ops";
 import { parseRawText } from "../parse-text";
+import { storyMapIO } from "./index";
 
 export function getLinkedPassageNames(passageContent: string): string[] {
 	const parts = passageContent.split(/\[(?:img)?\[/).slice(1);
@@ -120,4 +121,14 @@ export async function updatePassages(ctx: vscode.ExtensionContext, passages: Upd
 			languageId: "twee3"
 		});
 	}
+}
+
+export function focusPassage(context: vscode.ExtensionContext, storyMap: storyMapIO, editor: vscode.TextEditor) {
+	const passages = context.workspaceState.get("passages") as Passage[];
+	const editorPath = editor?.document.fileName.split("\\").filter((step) => step.length > 0) as [string];
+	const editorPosition = editor?.selection.active;
+	storyMap.client?.emit('focus-passage', passages.find((passage) => 
+		passage.origin.full.split("/").filter((step) => step.length > 0).every((step, index) => step == editorPath[index])
+		&& editorPosition && passage.range.start.line <= editorPosition.line && passage.range.end.line - 1 >= editorPosition.line // double check to appease typeerror
+	)?.name);
 }

--- a/story-map/src/App.vue
+++ b/story-map/src/App.vue
@@ -287,6 +287,20 @@ export default class AppComponent extends Vue {
     socket.on('connect', () => {
       console.log('connected');
     });
+    socket.on('focus-passage', (passageName) => {
+      let passage = this.passages.find((passage) => passage.name == passageName);
+      if (passage) {
+        this.selectedPassages = [passage];
+        let storyArea = document.querySelector(".story-area");
+        let target: Vector = {
+          x: ((passage.position.x + passage.size.x / 2) * this.zoom - storyArea.clientWidth / 2) * -1,
+          y: ((passage.position.y + passage.size.y / 2) * this.zoom - storyArea.clientHeight / 2) * -1,
+        };
+        this.translate = target;
+      } else {
+        console.error(`focus-passage: invalid passage name '${passageName}'`);
+      }
+    });
     socket.on('passage-data', (passageData: PassageData) => {
       const passages = passageData.list;
       console.log('Client received passages', { passages, storyData: passageData.storyData });

--- a/story-map/src/SaveToFileDialog/SaveToFile.vue
+++ b/story-map/src/SaveToFileDialog/SaveToFile.vue
@@ -451,6 +451,7 @@ export default class SaveToFile extends Vue {
             justify-content: flex-start;
             align-content: flex-start;
             height: calc(600px - 160px);
+            overflow: auto;
 
             .folder-item,
             .file-item {


### PR DESCRIPTION
Added a command to open the passage under the cursor on the story map to complement the open in VS Code feature of the map.

Please let me know if I've done anything strange here, this is the first extension development I've encountered.