### PR TITLE
Add relative path evaluation in macro md descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
 	"name": "twee3-language-tools",
-	"version": "0.19.1",
+	"version": "0.20.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "twee3-language-tools",
-			"version": "0.19.1",
+			"version": "0.20.4",
 			"license": "MIT",
 			"dependencies": {
 				"express": "^4.17.1",
@@ -25,7 +24,7 @@
 				"@types/mocha": "^7.0.2",
 				"@types/node": "^13.13.38",
 				"@types/uuid": "^8.3.0",
-				"@types/vscode": "^1.42.0",
+				"@types/vscode": "^1.67.0",
 				"@typescript-eslint/eslint-plugin": "^3.9.0",
 				"@typescript-eslint/parser": "^3.9.0",
 				"@vue/cli-plugin-babel": "~4.5.0",
@@ -1856,9 +1855,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-			"integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+			"version": "1.67.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
+			"integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
 			"dev": true
 		},
 		"node_modules/@types/webpack": {
@@ -18948,9 +18947,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-			"integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+			"version": "1.67.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
+			"integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
 			"dev": true
 		},
 		"@types/webpack": {
@@ -19409,6 +19408,7 @@
 				},
 				"ansi-regex": {
 					"version": "5.0.0",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
 				},
 				"ansi-styles": {
@@ -21285,6 +21285,7 @@
 			"dependencies": {
 				"ansi-regex": {
 					"version": "5.0.0",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
 				},
 				"ansi-styles": {
@@ -29349,6 +29350,7 @@
 				},
 				"ansi-regex": {
 					"version": "5.0.0",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
 				},
 				"emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -518,7 +518,7 @@
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^13.13.38",
 		"@types/uuid": "^8.3.0",
-		"@types/vscode": "^1.42.0",
+		"@types/vscode": "^1.67.0",
 		"@typescript-eslint/eslint-plugin": "^3.9.0",
 		"@typescript-eslint/parser": "^3.9.0",
 		"@vue/cli-plugin-babel": "~4.5.0",

--- a/src/sugarcube-2/configuration.ts
+++ b/src/sugarcube-2/configuration.ts
@@ -66,14 +66,20 @@ export const parseConfiguration = async function (): Promise<Configuration> {
 
 	for (let v of await vscode.workspace.findFiles("**/*.twee-config.{json,yaml,yml}", "**/node_modules/**")) {
 		let file = await vscode.workspace.openTextDocument(v);
-		let fileConfig: Configuration | null = null;
+		let fileConfig: Configuration = EMPTY_CONFIGURATION;
 		try {
 			fileConfig = yaml.parse(file.getText())["sugarcube-2"] || EMPTY_CONFIGURATION;
+			Object.values(fileConfig.macros).forEach(macro => {
+				if (typeof macro.description === "string") {
+					macro.description = new vscode.MarkdownString(macro.description);
+					macro.description.baseUri = v;
+				}
+			});
 		} catch (ex) {
 			vscode.window.showErrorMessage(`\nCouldn't parse ${file.fileName}!\n\n${ex}\n\n`);
 		}
 
-		if (fileConfig) {
+		if (fileConfig !== EMPTY_CONFIGURATION) {
 			// Merge the two configurations here.
 			Object.assign(configuration.macros, fileConfig.macros);
 		}

--- a/src/sugarcube-2/macros.ts
+++ b/src/sugarcube-2/macros.ts
@@ -26,7 +26,7 @@ export interface macro {
 
 export interface macroDef {
 	name?: MacroName;
-	description?: string,
+	description?: vscode.MarkdownString,
 	parameters?: Parameters,
 	container?: boolean;
 	selfClose?: boolean;
@@ -838,7 +838,7 @@ export const hover = async function (document: vscode.TextDocument, position: vs
 		// with a null prototype.
 		if (contained_in && Object.prototype.hasOwnProperty.call(macroDefinitions, macro.name)) {
 			let macroDefinition = macroDefinitions[macro.name];
-			if (typeof (macroDefinition.description) === "string") {
+			if (macroDefinition.description instanceof vscode.MarkdownString) {
 				return new vscode.Hover(macroDefinition.description);
 			} else {
 				// We found the macro the user is hovering over, but there is no description.


### PR DESCRIPTION
- Bumped minimum vscode types to 1.67 (last version supported by TS 3.9)
- Added baseUri property to macro descriptions (converting them to MarkdownString in the process) so Hover parses relative paths

```yaml
  description: "![Test img](./img/various/test.png)"
```
will now evaluate relative to the location of the definition file.

Implements #137 