### PR TITLE
Make sc2 macro names actually optional like documentation says

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ The following properties are currently programmed, even though not all of them a
 - **parameters** `(object)` *optional*: Allows for macro argument validation. [Read here](docs/parameters.md) for more information.
 - **decoration** `(object)` *optional*: Allows for declaring decorations to be displayed on that macro. Uses [DecorationRenderOptions](https://code.visualstudio.com/api/references/vscode-api#DecorationRenderOptions)' fields. Requires `definedMacroDecorations` setting to be enabled.
 
+The fields `description` and `parameters` allow substituting globally defined values in. [Read here](docs/enums.md) for more information.
+
 **NOTE:** Multiple `twee-config` files can be present in a workspace. They will stack and add to the macro definitions for the workspace. The recommended strategy is to make separate files for separate macro sets/libraries, e.g. (the following file can also be used as an example):
 - `click-to-proceed.twee-config.yaml` ([Link](https://github.com/cyrusfirheir/cycy-wrote-custom-macros/blob/master/click-to-proceed/click-to-proceed.twee-config.yaml))
 

--- a/docs/enums.md
+++ b/docs/enums.md
@@ -1,0 +1,53 @@
+# Enum substitution
+In macro definition configuration files, variables can be defined that are inserted into the definitions after all configurations are loaded. These values are referred to as `enums` and work across all configurations, no matter which file they are defined in. This document goes over some high-level details of how it works, and how to use it with the extension. The operation is a simple string for string substitution with no validation or pre-processing.
+  
+## Enum syntax
+**Supported**: Sugarcube 2
+`%enumName%`
+
+Valid characters for enums are alphanumeric characters and underscore (a-z, A-Z, 0-9, _).
+
+Enums are respected and substituted inside macro `description` and `parameters` fields.
+
+- If using `*.twee-config.yaml` (indentation is important for YAML files):
+  ```yaml
+  sugarcube-2:
+    enums:
+      colors: '"red"|"green"|"blue"|"pink"'
+    macros:
+      coloredbutton:
+        name: coloredbutton
+        description: |-
+          `<<coloredbutton label color>>`
+
+          `label`: What the button says
+
+          `color`: %colors%
+        parameters:
+          - text &+ %colors%
+  ```
+- If using `*.twee-config.json`:
+  ```json
+  {
+    "sugarcube-2": {
+      "enums": {
+        "colors": "\"red\"|\"green\"|\"blue\"|\"pink\""
+      },
+      "macros": {
+        "coloredbutton": {
+          "name": "coloredbutton",
+          "description": "`<<coloredbutton label color>>`\n\n`label`: What the button says\n\n`color`: %colors%",
+          "parameters": [
+            "text &+ %colors%"
+          ]
+        }
+      }
+    }
+  }
+  ```
+
+**Note**: Enums are evaluated globally and order of files processed is not guaranteed. Redefining enums differently in multiple locations may yield inconsistent results.
+
+The extension provides the following enums by default:
+
+**workspaceDir**: Root directory of the workspace opened in vscode. Will return a proper Uri for evaluation in local and web views.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "twee3-language-tools",
-	"version": "0.20.4",
+	"version": "0.20.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "twee3-language-tools",
-			"version": "0.20.4",
+			"version": "0.20.5",
 			"license": "MIT",
 			"dependencies": {
 				"express": "^4.17.1",
-				"glob": "^7.1.6",
+				"glob": "^7.2.0",
+				"lodash": "^4.17.21",
 				"minimatch": "^3.0.4",
 				"open": "^7.3.1",
 				"socket.io": "^3.0.5",
@@ -20,7 +20,8 @@
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.9",
-				"@types/glob": "^7.1.3",
+				"@types/glob": "^7.2.0",
+				"@types/lodash": "^4.14.182",
 				"@types/minimatch": "^3.0.3",
 				"@types/mocha": "^7.0.2",
 				"@types/node": "^13.13.38",
@@ -1708,9 +1709,9 @@
 			}
 		},
 		"node_modules/@types/glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
 			"dev": true,
 			"dependencies": {
 				"@types/minimatch": "*",
@@ -1747,6 +1748,12 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
 			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+			"dev": true
+		},
+		"node_modules/@types/lodash": {
+			"version": "4.14.182",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+			"integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
 			"dev": true
 		},
 		"node_modules/@types/mime": {
@@ -8698,9 +8705,9 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -10502,8 +10509,7 @@
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/lodash.defaultsdeep": {
 			"version": "4.6.1",
@@ -18823,9 +18829,9 @@
 			}
 		},
 		"@types/glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
 			"dev": true,
 			"requires": {
 				"@types/minimatch": "*",
@@ -18864,6 +18870,12 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
 			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+			"dev": true
+		},
+		"@types/lodash": {
+			"version": "4.14.182",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+			"integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
 			"dev": true
 		},
 		"@types/mime": {
@@ -24438,9 +24450,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -25839,8 +25851,7 @@
 		"lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"lodash.defaultsdeep": {
 			"version": "4.6.1",

--- a/package.json
+++ b/package.json
@@ -166,6 +166,11 @@
 		"configuration": {
 			"title": "Twee 3 Language Tools",
 			"properties": {
+				"twee3LanguageTools.yaml.maxAliasCount": {
+					"type": "integer",
+					"default": 100,
+					"markdownDescription": "Max number of alias substitutions allowed in a single yaml file"
+				},
 				"twee3LanguageTools.storyformat.current": {
 					"type": "string",
 					"default": "",

--- a/package.json
+++ b/package.json
@@ -514,7 +514,8 @@
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.9",
-		"@types/glob": "^7.1.3",
+		"@types/glob": "^7.2.0",
+		"@types/lodash": "^4.14.182",
 		"@types/minimatch": "^3.0.3",
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^13.13.38",
@@ -543,7 +544,8 @@
 	},
 	"dependencies": {
 		"express": "^4.17.1",
-		"glob": "^7.1.6",
+		"glob": "^7.2.0",
+		"lodash": "^4.17.21",
 		"minimatch": "^3.0.4",
 		"open": "^7.3.1",
 		"socket.io": "^3.0.5",

--- a/src/sugarcube-2/configuration.ts
+++ b/src/sugarcube-2/configuration.ts
@@ -118,8 +118,9 @@ export const parseConfiguration = async function (): Promise<Configuration> {
  * @returns {Object | Error}
  */
 export const yamlParse = function(text: string, header?: string, options?: yaml.Options): any {
+	const yamlDefaults = vscode.workspace.getConfiguration("twee3LanguageTools.yaml");
 	const defaults = {
-		maxAliasCount: 1000,
+		maxAliasCount: yamlDefaults.get("maxAliasCount"),
 	};
 
 	options = Object.assign(defaults, options);

--- a/src/sugarcube-2/macros.ts
+++ b/src/sugarcube-2/macros.ts
@@ -97,6 +97,8 @@ export const onUpdateMacroCache = function (lastMacroCache: Record<string, macro
 			}
 		}
 
+		if (!macro.name) macro.name = key;
+
 		if (typeof macro.description?.value === "string") {
 			macro.description.value = parseEnums(macro.description.value, enums);
 		}

--- a/src/sugarcube-2/parameters.ts
+++ b/src/sugarcube-2/parameters.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { Passage } from '../passage';
 import { Arg, ArgType, ExpressionArgument, ParsedArguments, SettingsSetupAccessArgument, VariableArgument } from './arguments';
 import { StateInfo, Warning } from './validation';
+import { parseEnums } from './macros';
 
 export type UnparsedFormat = string;
 // Note: This may eventually also be allowed to become an object, for more configuration options.
@@ -178,7 +179,7 @@ interface ArgumentInfo {
  * @param list The list of macros. Modified in-place.
  * @returns {Error[]} A potentially empty list of errors that occurred.
  */
-export function parseMacroParameters(list: Record<string, Record<string, any>>): Error[] {
+export function parseMacroParameters(list: Record<string, Record<string, any>>, enums: Record<string, string>): Error[] {
     let errors: Error[] = [];
     for (let key in list) {
         let macroDefinition = list[key];
@@ -192,6 +193,10 @@ export function parseMacroParameters(list: Record<string, Record<string, any>>):
             delete macroDefinition.parameters;
             continue;
         }
+
+        macroDefinition.parameters = macroDefinition.parameters.map((parameter: string) => {
+            return parseEnums(parameter, enums);
+        });
 
         try {
             // Overwrite the previous parameters with the parsed version

--- a/src/sugarcube-2/parameters.ts
+++ b/src/sugarcube-2/parameters.ts
@@ -261,7 +261,7 @@ export class Parameters {
      * Checks if two Parameters are loosely equivalent
      */
     compare(other: Parameters): boolean {
-        if (this.variants.length !== other.variants.length) {
+        if (this.variants.length !== other.variants?.length) {
             // Different amount of variants so they cannot be equivalent.
             return false;
         }

--- a/src/sugarcube-2/validation.ts
+++ b/src/sugarcube-2/validation.ts
@@ -4,6 +4,7 @@
 */
 
 import { Passage } from "../passage";
+import _ from "lodash";
 
 // SugarCube has more complex checks for these, but we're only supporting VSCode and assume its
 // whitespace handling is sane.
@@ -98,43 +99,46 @@ export function isArraySimpleObjectsEqual(left?: Record<string, any>[], right?: 
  * isEqual
  */
 export function isObjectSimpleEqual(left?: Record<string, any>, right?: Record<string, any>): boolean {
-    if (left === right) {
-        // They're the same object
-        return true;
-    } else if (left === undefined || right === undefined) {
-        return false;
-    }
+    return _.isEqual(left, right);
+    // if (left === right) {
+    //     // They're the same object
+    //     return true;
+    // } else if (left === undefined || right === undefined) {
+    //     return false;
+    // }
 
-    let left_keys = Object.keys(left);
-    let right_keys = Object.keys(right);
+    // let left_keys = Object.keys(left);
+    // let right_keys = Object.keys(right);
 
-    if (left_keys.length != right_keys.length) {
-        return false;
-    }
+    
 
-    for (let i = 0; i < left_keys.length; i++) {
-        let key = left_keys[i];
-        if (!(key in right)) {
-            return false;
-        }
+    // if (left_keys.length != right_keys.length) {
+    //     return false;
+    // }
 
-        if (left[key] !== right[key]) {
-            return false;
-        }
-    }
+    // for (let i = 0; i < left_keys.length; i++) {
+    //     let key = left_keys[i];
+    //     if (!(key in right)) {
+    //         return false;
+    //     }
 
-    for (let i = 0; i < right_keys.length; i++) {
-        let key = right_keys[i];
-        if (!(key in left)) {
-            return false;
-        }
+    //     if (left[key] !== right[key]) {
+    //         return false;
+    //     }
+    // }
 
-        if (left[key] !== right[key]) {
-            return false;
-        }
-    }
+    // for (let i = 0; i < right_keys.length; i++) {
+    //     let key = right_keys[i];
+    //     if (!(key in left)) {
+    //         return false;
+    //     }
 
-    return true;
+    //     if (left[key] !== right[key]) {
+    //         return false;
+    //     }
+    // }
+
+    // return true;
 }
 
 

--- a/src/twee-project.ts
+++ b/src/twee-project.ts
@@ -56,7 +56,7 @@ export async function tweeProjectConfig(context: vscode.ExtensionContext) {
 	}
 };
 
-export async function changeStoryFormat(document: vscode.TextDocument) {
+export async function changeStoryFormat(document: vscode.TextDocument): Promise<vscode.TextDocument> {
 	const config = vscode.workspace.getConfiguration("twee3LanguageTools.storyformat");
 	const langs = await vscode.languages.getLanguages();
 
@@ -65,6 +65,7 @@ export async function changeStoryFormat(document: vscode.TextDocument) {
 	if (!langs.includes(format)) format = "twee3";
 
 	if (/^twee3.*/.test(document.languageId) && document.languageId !== format) {
-		await vscode.languages.setTextDocumentLanguage(document, format);
+		return vscode.languages.setTextDocumentLanguage(document, format);
 	}
+	return Promise.resolve(document);
 };


### PR DESCRIPTION
If a macro name is not provided, the name will now be inferred by the configuration's key.

This fixes an issue where all unnamed macros were receiving the same decoration.