### PR TITLE
Add basic Definition support for sc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,6 +252,14 @@
 					"default": true,
 					"markdownDescription": "Highlight opening and closing tags of container macros?"
 				},
+				"twee3LanguageTools.sugarcube-2.widgetAliases": {
+					"type": "array",
+					"default": [
+						"<<widget ",
+						"Macro\\.add\\("
+					],
+					"markdownDescription": "Regex alternatives when searching for macro definitions"
+				},
 				"twee3LanguageTools.sugarcube-2.warning.undefinedMacro": {
 					"type": "boolean",
 					"default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,10 @@ const documentSelector: vscode.DocumentSelector = {
 	pattern: "**/*.{tw,twee}",
 };
 
+const configurationSelector: vscode.DocumentSelector = {
+	pattern: "**/*twee-config.{yml,json}",
+};
+
 export const PackageLanguages = PackageContributions.languages.map(el => el.id);
 
 export async function activate(ctx: vscode.ExtensionContext) {
@@ -135,6 +139,18 @@ export async function activate(ctx: vscode.ExtensionContext) {
 					default: return null;
 				}
 			}
+		})
+		,
+		vscode.languages.registerDefinitionProvider(documentSelector, {
+			provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Definition|vscode.LocationLink[]> {
+					return sugarcube2Macros.definition(ctx, document, position, token);
+			},
+		})
+		,
+		vscode.languages.registerDefinitionProvider(configurationSelector, {
+			provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Definition|vscode.LocationLink[]> {
+					return sugarcube2Macros.definitionConfig(ctx, document, position, token);
+			},
 		})
 		,
 		vscode.window.onDidChangeTextEditorSelection(async e => {

--- a/src/sugarcube-2/configuration.ts
+++ b/src/sugarcube-2/configuration.ts
@@ -129,6 +129,7 @@ export const parseConfiguration = async function (): Promise<Configuration> {
 export const yamlParse = function(text: string, header?: string, options?: yaml.Options): any {
 	const yamlDefaults = vscode.workspace.getConfiguration("twee3LanguageTools.yaml");
 	const defaults = {
+		merge: true,
 		maxAliasCount: yamlDefaults.get("maxAliasCount"),
 	};
 

--- a/src/sugarcube-2/parameters.ts
+++ b/src/sugarcube-2/parameters.ts
@@ -189,20 +189,19 @@ export function parseMacroParameters(list: Record<string, Record<string, any>>, 
             // Ignore parameters that have already been parsed.
             continue;
         } else if (!Array.isArray(macroDefinition.parameters)) {
-            errors.push(new Error(`Error while checking parameters of '${macroDefinition.name}': The parameters were not an array of strings.`));
+            errors.push(new Error(`Error while checking parameters of '${macroDefinition.name || key}': The parameters were not an array of strings.`));
             delete macroDefinition.parameters;
             continue;
         }
 
-        macroDefinition.parameters = macroDefinition.parameters.map((parameter: string) => {
-            return parseEnums(parameter, enums);
-        });
-
         try {
+            macroDefinition.parameters = macroDefinition.parameters.map((parameter: string) => {
+                return parseEnums(parameter || "", enums);
+            });
             // Overwrite the previous parameters with the parsed version
             macroDefinition.parameters = new Parameters(macroDefinition.parameters);
         } catch (err) {
-            errors.push(new Error(`Error while parsing parameters of '${macroDefinition.name}': ${(err as Error).message || "Failed to get error message, please report this."}`));
+            errors.push(new Error(`Error while parsing parameters of '${macroDefinition.name || key}': ${(err as Error).message || "Failed to get error message, please report this."}`));
         }
     }
     return errors;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,12 @@
 	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es2017",
+		"target": "es2019",
 		"outDir": "out",
 		"rootDir": ".",
 		"esModuleInterop": true,
 		"lib": [
-			"es2017"
+			"es2019"
 		],
 		"sourceMap": true
 	},


### PR DESCRIPTION
### Features:
- Add Definition and Definition Peak support to macros. Supported in twee, js, yml, and json files
- Enable support for yaml 1.1's alias merges
- Bump es compiler target to es2019

### API:
- New user setting `twee3LanguageTools.sugarcube-2.widgetAliases`
	- User defined list of regex searches that are equivalent to native sugarcube-2 macro definitions
	- Defaults to `[ "<<widget ", "Macro\\.add\\(" ]`

### Bug Fixes:
- Parameters could crash configuration parsing if not defined as array of strings
- Parameter parsing error messages assumed hard requirement for macro names

### Definition Limitations:
- TextDocument lifespan is completely handled by vscode internally. Secondary lookup can sometimes fail (gracefully) if js definition provider hasn't been loaded and registered yet
	- Alternative solutions were considered too hacky to be worth it since the hacks would have to be maintained
- Lookup is about twice as slow as it could theoretically be
	- Would require pre-generating statically defined macro symbols
- Definition is only provided for macro at position of typing cursor (as "intended" by vscode)
	- Definition support could be expanded to be provided for pointer over hover text (to allow definition jumping inside hover documentation)