### PR TITLE
Improves performance in large projects and fixes various bugs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,7 +114,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
 		await Promise.all(results.map(document => {
 			if (document) {
 				log.trace(`[Startup] Updating storyformat and diagnostics "${document.uri.path}"`);
-				return changeStoryFormat(document);
+				return changeStoryFormat(document).then(d => updateDiagnostics(ctx, d, collection));
 			}
 			return null;
 		}));

--- a/src/parse-text.ts
+++ b/src/parse-text.ts
@@ -185,6 +185,34 @@ export async function parseRawText(context: vscode.ExtensionContext, document: R
 		newPassages.push(lastPassage);
 	}
 
+	for (const newPassage of newPassages) {
+		if (
+			newPassage.tags?.includes("script") || 
+			newPassage.tags?.includes("stylesheet") ||
+			newPassage.tags?.includes("init") || 
+			[
+				"PassageDone", "PassageReady", "StoryAuthor", 
+				"StoryInit", "StoryInterface", "StoryMenu", 
+				"StorySettings", "StoryShare", "StoryData"
+			].includes(newPassage.name)
+		) {
+			continue;
+		}
+		newPassage.meta ??= {};
+		const passageText = document.text.substring(newPassage.stringRange.endHeader, newPassage.stringRange.end).trim()
+		if (document.languageId === sugarcube2Language.LanguageID) {
+			Object.assign(newPassage.meta, {
+				wordCount: countWords(passageText),
+				macroCount: countMacro(passageText),
+			});
+		}
+		else {
+			Object.assign(newPassage.meta, {
+				wordCount: genericCountWords(passageText),
+			});
+		}
+	}
+
 	if (!passageStore) {
 		await context.workspaceState.update("passages", passages.concat(newPassages));
 		if (document.languageId === sugarcube2Language.LanguageID) sugarcube2Macros.argumentCache.clearMacrosUsingPassage();
@@ -198,11 +226,73 @@ export async function parseRawText(context: vscode.ExtensionContext, document: R
 }
 
 export async function parseText(context: vscode.ExtensionContext, document: vscode.TextDocument, passageStore?: (value: Passage[] | PromiseLike<Passage[]>) => void): Promise<IParsedToken[]> {
+	const config = vscode.workspace.getConfiguration("twee3LanguageTools.storyformat");
+	const languageFormat = "twee3-" + (config.get("override") || config.get("current"));
+
 	return parseRawText(context, {
 		text: document.getText(),
 		uri: document.uri,
-		languageId: document.languageId
+		languageId: languageFormat
 	}, passageStore);
+}
+
+const commentRegex = /\/%.*?%\/|\/\*.*?\*\/|<!--.*?-->/gs;
+const htmlTagRegex = /<[^>]+>/g;
+const macroRegex = /<<([^>]+)>>/g;
+const quoteRegex = /["']([^"']+)["']/g;
+const wordRegex = /[a-zA-Z0-9]+(?:[-–—'’][a-zA-Z0-9]+)*/g;
+
+function countWords(text: string): number {
+	text = text.replace(/<<.*?>>/gs, ''); // Remove macros
+	text = text.replace(/\[[^\]]*\]/g, ''); // Remove content inside [] because Link/Text/Setter is low volume
+	text = text.replace(commentRegex, ''); // Remove comments
+	text = text.replace(htmlTagRegex, ' '); // Remove HTML tags
+	text = text.replace(/\s+/g, ' ').trim(); // Normalize spaces
+
+	const words = text.match(wordRegex) || [];
+	return words.length;
+}
+
+function countMacro(text: string): number {
+	let totalWordCount = 0;
+	let match;
+
+	while ((match = macroRegex.exec(text)) !== null) {
+		const macroContent = match[1];
+		const quotedWords = macroContent.match(quoteRegex);
+		
+		if (quotedWords) {
+			for (const quote of quotedWords) {
+				const wordString = quote.slice(1, -1);
+				const words = wordString.split(/\s+/).filter(word => word.length > 0);
+				totalWordCount += words.length;
+			}
+		}
+	}
+
+	return totalWordCount;
+}
+
+function genericCountWords(text: string): number {
+	text = text.normalize('NFKD');
+	text = text.replace(/\n/g, '');
+	const commentRegex = /\/%.*?%\/|\/\*.*?\*\/|<!--.*?-->/gs;
+	text = text.replace(commentRegex, '');
+
+	let charCount = 0;
+
+	for (const char of text) {
+		if (char.trim()) {
+			charCount++;
+		}
+	}
+
+	let words = Math.floor(charCount / 5);
+	if (charCount % 5 > 0) {
+		words++;
+	}
+
+	return words;
 }
 
 const tokenTypes = new Map<string, number>();


### PR DESCRIPTION
Adds:
- Word and passage counter now displays number with locale aware thousands separator

Changes:
- Word and macro word counts are cached in passage meta object
- Word counts are done when each individual file is parsed

Fixes:
- Diagnostics not being updated on initial load
- Saving a file would cause every file to be reparsed
- Parse text could not safely be done before story format was set