### PR TITLE
Allow some unbalanced brackets in Harlowe def

### DIFF
--- a/defs/harlowe-3/grammar.json
+++ b/defs/harlowe-3/grammar.json
@@ -220,10 +220,13 @@
 			"patterns": [
 				{
 					"name": "meta.harlowe.collapsed-unclosed.twee3",
-					"begin": "(\\{=+)",
+					"begin": "(\\{)=+",
 					"beginCaptures": {
-						"1": {
+						"0": {
 							"name": "punctuation.separator.twee3"
+						},
+						"1": {
+							"name": "meta.harlowe.unbalanced.twee3"
 						}
 					},
 					"end": "^(?=::)|(?=\\])",
@@ -262,13 +265,16 @@
 			"patterns": [
 				{
 					"name": "meta.harlowe.hooks-unclosed.twee3",
-					"begin": "(\\|[a-zA-Z0-9]\\w*[\\>\\)])(\\[=+)",
+					"begin": "(\\|[a-zA-Z0-9]\\w*[\\>\\)])((\\[)=+)",
 					"beginCaptures": {
 						"1": {
 							"name": "entity.name.tag.hook"
 						},
 						"2": {
 							"name": "punctuation.separator.twee3"
+						},
+						"3": {
+							"name": "meta.harlowe.unbalanced.twee3"
 						}
 					},
 					"end": "^(?=:: )|(?=\\])",
@@ -318,10 +324,13 @@
 			"patterns": [
 				{
 					"name": "meta.harlowe.hooks-unclosed.twee3",
-					"begin": "\\[=+",
+					"begin": "(\\[)=+",
 					"beginCaptures": {
 						"0": {
 							"name": "punctuation.separator.twee3"
+						},
+						"1": {
+							"name": "meta.harlowe.unbalanced.twee3"
 						}
 					},
 					"end": "^(?=:: )|(?=\\])",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,10 @@
 				"language": "twee3-harlowe-3",
 				"scopeName": "source.harlowe-3.twee3",
 				"path": "./defs/harlowe-3/grammar.json",
+				"unbalancedBracketScopes": [
+					"meta.harlowe.unbalanced.twee3",
+					"entity.name.tag.hook"
+				],
 				"embeddedLanguages": {
 					"source.json.twee3": "json",
 					"source.js.twee3": "javascript",


### PR DESCRIPTION
VSCode was throwing a fit when the brackets `[]{}()` in hidden hook names, unclosed hooks, and unclosed whitespace were unbalanced. This uses the `unbalancedBracketScopes` configuration option to let it know those don't need a partner.