### PR TITLE
Fix Windows drive-letter case loop in onDidOpenTextDocument

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -2,11 +2,13 @@ import * as vscode from 'vscode';
 import { diagnostics as sc2 } from './sugarcube-2/macros';
 import { LanguageID as SC2LanguageID } from './sugarcube-2/configuration';
 import { getWorkspacePassages, Passage } from './passage';
+import { normalizePath } from './utils';
 
 export const updateDiagnostics = async function (ctx: vscode.ExtensionContext, document: vscode.TextDocument, collection: vscode.DiagnosticCollection) {
 	if (!/^twee3.*/.test(document.languageId)) return;
 
-	const passages: Passage[] = getWorkspacePassages(ctx).filter(passage => passage.origin.full === document.uri.path);
+	const docPath = normalizePath(document.uri.path);
+	const passages: Passage[] = getWorkspacePassages(ctx).filter(passage => normalizePath(passage.origin.full) === docPath);
 
 	const diagnostics = (await Promise.all(
 		passages.map(async (passage) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ import { passageCounter } from './status-bar';
 import { wordCounter } from './status-bar';
 import { sbStoryMapConfirmationDialog } from './status-bar';
 import { updateDecorations, updateTextEditorDecorations } from './decorations';
-import { tabstring } from './utils';
+import { tabstring, normalizePath } from './utils';
 
 import { activateFolding } from './folding';
 //#endregion
@@ -173,6 +173,16 @@ export async function activate(ctx: vscode.ExtensionContext) {
 		treeDataProvider: passageListProvider
 	});
 
+	// Reentrancy guard for onDidOpenTextDocument.
+	//
+	// `changeStoryFormat` may call `vscode.languages.setTextDocumentLanguage`, which closes and
+	// reopens the document, triggering another `onDidOpenTextDocument`. With concurrent callers
+	// (rename handler + open handler) and Windows drive-letter case drift, this can cascade into
+	// the high-CPU loop reported in https://github.com/cyrusfirheir/twee3-language-tools — see the
+	// "lowercase d:/" traces in the bug thread. Guard by normalized URI so only one update runs
+	// per document at a time.
+	const openDocumentsInFlight = new Set<string>();
+
 	const createDebouncedParseTextAndDiagnostics = () => {
 		const parseTextConfig = vscode.workspace.getConfiguration("twee3LanguageTools.parseText");
 		return debounce(async (document: vscode.TextDocument) => {
@@ -251,10 +261,20 @@ export async function activate(ctx: vscode.ExtensionContext) {
 		,
 		vscode.workspace.onDidOpenTextDocument(async document => {
 			if (!/^twee3.*/.test(document.languageId)) return;
-			log.trace(`[Document opened] Updating diagnostics: "${document.uri.path}"`);
-			await changeStoryFormat(document);
-			updateDiagnostics(ctx, document, collection);
-			updateTextEditorDecorations(ctx);
+			const key = normalizePath(document.uri.path);
+			if (openDocumentsInFlight.has(key)) {
+				log.trace(`[Document opened] Skipping reentrant update: "${document.uri.path}"`);
+				return;
+			}
+			openDocumentsInFlight.add(key);
+			try {
+				log.trace(`[Document opened] Updating diagnostics: "${document.uri.path}"`);
+				await changeStoryFormat(document);
+				updateDiagnostics(ctx, document, collection);
+				updateTextEditorDecorations(ctx);
+			} finally {
+				openDocumentsInFlight.delete(key);
+			}
 		})
 		,
 		vscode.workspace.onDidChangeTextDocument(e => {
@@ -305,9 +325,9 @@ export async function activate(ctx: vscode.ExtensionContext) {
 		vscode.workspace.onDidDeleteFiles(e => {
 			e.files.forEach(file => sugarcube2Macros.collectCache.clearFilename(file.fsPath));
 
-			const removedFilePaths = e.files.map((file) => file.path);
+			const removedFilePaths = new Set(e.files.map((file) => normalizePath(file.path)));
 			const oldPassages: Passage[] = getWorkspacePassages(ctx);
-			const newPassages: Passage[] = oldPassages.filter((passage) => !removedFilePaths.includes(passage.origin.full));
+			const newPassages: Passage[] = oldPassages.filter((passage) => !removedFilePaths.has(normalizePath(passage.origin.full)));
 			ctx.workspaceState.update("passages", newPassages).then(() => {
 				if (storyMap.client) sendPassageDataToClient(ctx, storyMap.client);
 				if (vscode.workspace.getConfiguration("twee3LanguageTools.passage").get("list")) passageListProvider.refresh();
@@ -321,12 +341,14 @@ export async function activate(ctx: vscode.ExtensionContext) {
 
 				sugarcube2Macros.collectCache.clearFilename(file.oldUri.fsPath);
 
+				const oldPath = normalizePath(file.oldUri.path);
+				const newPath = normalizePath(file.newUri.path);
 				let passages: Passage[] = getWorkspacePassages(ctx);
 				passages.forEach(el => {
-					if (el.origin.full === file.oldUri.path) {
-						el.origin.root = vscode.workspace.getWorkspaceFolder(file.newUri)?.uri.path || "";
-						el.origin.path = file.newUri.path.replace(el.origin.root, "");
-						el.origin.full = file.newUri.path;
+					if (normalizePath(el.origin.full) === oldPath) {
+						el.origin.root = normalizePath(vscode.workspace.getWorkspaceFolder(file.newUri)?.uri.path || "");
+						el.origin.path = newPath.replace(el.origin.root, "");
+						el.origin.full = newPath;
 					}
 				});
 				await ctx.workspaceState.update("passages", passages);

--- a/src/extract-passage.ts
+++ b/src/extract-passage.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { getWorkspacePassages, Passage } from "./passage";
 import { moveToFile, MoveData } from "./file-ops";
+import { normalizePath } from "./utils";
 
 export class ExtractPassage implements vscode.CodeActionProvider {
   public static readonly providedCodeActionKinds = [
@@ -17,15 +18,11 @@ export class ExtractPassage implements vscode.CodeActionProvider {
   ): vscode.CodeAction[] | undefined {
     const passages = getWorkspacePassages(this.context);
 
-    // Use fsPath for comparison if available, or normalize
-    const docPath = document.uri.fsPath;
+    const docPath = normalizePath(document.uri.path);
 
     const passage = passages.find((p) => {
-      // p.origin.full might be path or fsPath depending on how it was created
-      // Try to match both or normalize
       return (
-        (p.origin.full === docPath ||
-          vscode.Uri.file(p.origin.full).fsPath === docPath) &&
+        normalizePath(p.origin.full) === docPath &&
         p.range.start.line === range.start.line
       );
     });

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -5,6 +5,7 @@ import { minimatch } from "minimatch";
 
 import { Passage, PassageOrigin, PassageRange, PassageStringRange } from "./passage";
 import { parseRawText } from "./parse-text";
+import { normalizePath } from "./utils";
 
 export async function readFile(path: string) {
 	return Buffer.from(await vscode.workspace.fs.readFile(vscode.Uri.file(path))).toString("utf-8");
@@ -29,7 +30,7 @@ export interface MoveData {
 export async function moveToFile(context: vscode.ExtensionContext, moveData: MoveData) {
 	// Make thepassages appear in the order they were
 	const sortedPassages = moveData.passages.slice().sort((a, b) => {
-		const fileCompare = a.origin.full.localeCompare(b.origin.full);
+		const fileCompare = normalizePath(a.origin.full).localeCompare(normalizePath(b.origin.full));
 		if (fileCompare !== 0) return fileCompare;
 		if (a.range.startLine > b.range.startLine) return 1;
 		if (a.range.startLine < b.range.startLine) return -1;
@@ -38,13 +39,13 @@ export async function moveToFile(context: vscode.ExtensionContext, moveData: Mov
 
 	// Update files
 	let text: string[] = new Array(sortedPassages.length);
-	
-	const files = [... new Set(moveData.passages.map(passage => passage.origin.full))];
+
+	const files = [... new Set(moveData.passages.map(passage => normalizePath(passage.origin.full)))];
 	for (const file of files) {
 		const fDocText = await readFile(file);
 		let edited = fDocText;
 
-		const filePassages = moveData.passages.filter(el => el.origin.full === file);
+		const filePassages = moveData.passages.filter(el => normalizePath(el.origin.full) === file);
 
 		for (const passage of filePassages) {
 			const p = new Passage(passage.name, new vscode.Range(

--- a/src/parse-text.ts
+++ b/src/parse-text.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { getWorkspacePassages, Passage, PassageListProvider } from "./passage";
 import * as sugarcube2Macros from "./sugarcube-2/macros";
 import * as sugarcube2Language from "./sugarcube-2/configuration";
+import { normalizePath } from "./utils";
 
 interface IParsedToken {
 	line: number;
@@ -21,7 +22,8 @@ export interface RawDocument {
 
 export async function parseRawText(context: vscode.ExtensionContext, document: RawDocument, passageStore?: (value: Passage[] | PromiseLike<Passage[]>) => void): Promise<IParsedToken[]> {
 	const StoryData: any = context.workspaceState.get("StoryData", {});
-	const passages = getWorkspacePassages(context).filter(el => el.origin.full !== document.uri.path);
+	const docPath = normalizePath(document.uri.path);
+	const passages = getWorkspacePassages(context).filter(el => normalizePath(el.origin.full) !== docPath);
 	const newPassages: Passage[] = [];
 
 	const r: IParsedToken[] = [];
@@ -130,14 +132,14 @@ export async function parseRawText(context: vscode.ExtensionContext, document: R
 				tokenModifiers: []
 			});
 
-			const root = vscode.workspace.getWorkspaceFolder(document.uri)?.uri.path || "";
-			const path = document.uri.path.replace(root, "");
+			const root = normalizePath(vscode.workspace.getWorkspaceFolder(document.uri)?.uri.path || "");
+			const path = docPath.replace(root, "");
 
 			let passage = new Passage(
 				passageName,
 				new vscode.Range(i, 0, i + 1, 0),
 				{ start: curStart, endHeader: curEnd, end: curEnd },
-				{ root, path, full: document.uri.path },
+				{ root, path, full: docPath },
 				vscode.TreeItemCollapsibleState.None
 			);
 

--- a/src/passage.ts
+++ b/src/passage.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 
 import { readFile } from "./file-ops";
+import { normalizePath } from "./utils";
 
 export class PassageListProvider implements vscode.TreeDataProvider<Passage> {
 	private _onDidChangeTreeData: vscode.EventEmitter<Passage | undefined | void> = new vscode.EventEmitter<Passage | undefined | void>();
@@ -36,8 +37,9 @@ export class PassageListProvider implements vscode.TreeDataProvider<Passage> {
 				});
 
 				if (element) {
+					const target = normalizePath(element.origin.full);
 					return Promise.resolve(passages
-						.filter(el => el.origin.full === element.origin.full)
+						.filter(el => normalizePath(el.origin.full) === target)
 						.sort((a, b) => a.name.localeCompare(b.name))
 					);
 				} else return Promise.resolve(files.sort((a, b) => a.name.localeCompare(b.name)));
@@ -197,11 +199,9 @@ export function jumpToPassage(passage: Passage | OpenPassageParams) {
 
 export function passageAtCursor(context: vscode.ExtensionContext, editor: vscode.TextEditor) {
 	const passages = getWorkspacePassages(context);
-	const editorPath = editor?.document.uri.path.split("/").filter((step) => step.length > 0) as [string];
+	const editorPath = normalizePath(editor?.document.uri.path);
 	const editorPosition = editor?.selection.active;
-	return passages.find((passage) => passage.origin.full.split("/")
-		.filter((step) => step.length > 0)
-		.every((step, index) => step === editorPath[index])
+	return passages.find((passage) => normalizePath(passage.origin.full) === editorPath
 		&& editorPosition && passage.range.start.line <= editorPosition.line && passage.range.end.line - 1 >= editorPosition.line
 		/* double check to appease typeerror */
 	);
@@ -221,8 +221,9 @@ export class PassageSymbolProvider implements vscode.DocumentSymbolProvider {
 	
 	provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
 		const symbols: vscode.SymbolInformation[] = [];
+		const docPath = normalizePath(document.uri.path);
 		getWorkspacePassages(this.context).forEach(passage => {
-			if (passage.origin.full === document.uri.path) {
+			if (normalizePath(passage.origin.full) === docPath) {
 				symbols.push(createPassageSymbol(passage));
 			}
 		});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,34 @@
 import * as vscode from "vscode";
 
+/**
+ * Normalize a URI path for identity comparison.
+ *
+ * On Windows, file paths are case-insensitive but VS Code's various APIs
+ * (globSync, Uri.file, onDidRenameFiles, setTextDocumentLanguage, FileSystemWatcher, ...)
+ * do not agree on drive-letter casing. Two Uris pointing at the same file
+ * can appear as `/D:/foo/bar.tw` and `/d:/foo/bar.tw`. Case-sensitive `===`
+ * comparisons against `origin.full` / `document.uri.path` then silently miss,
+ * producing duplicate passage records and lost-lookup filters that fuel the
+ * high-CPU loop reported in https://github.com/cyrusfirheir/twee3-language-tools
+ *
+ * This normalizes the Windows drive letter to lowercase. On other platforms
+ * it is a no-op since paths are case-sensitive there.
+ */
+export function normalizePath(p: string): string {
+	if (process.platform === "win32") {
+		return p.replace(/^(\/?)([a-zA-Z]):/, (_m, slash, letter) => slash + letter.toLowerCase() + ":");
+	}
+	return p;
+}
+
+export function pathsEqual(a: string, b: string): boolean {
+	return normalizePath(a) === normalizePath(b);
+}
+
+export function uriPath(uri: vscode.Uri): string {
+	return normalizePath(uri.path);
+}
+
 export function headsplit(raw: string, regexp: RegExp, caps: number = 1) {
 	const text = raw.trim().split(/\r?\n/);
 	let retArr: { header: string; content: string }[] = [],


### PR DESCRIPTION
The high-CPU loop reported at https://github.com/cyrusfirheir/twee3-language-tools (discussed with AlyxMS and traced to "lowercase d:/" vs "uppercase D:/" diagnostic updates) had two contributing root causes on Windows:

1. Case-sensitive path identity. VS Code's various APIs (globSync, Uri.file, onDidRenameFiles, setTextDocumentLanguage reopen, FileSystemWatcher, etc.) do not agree on drive-letter casing, so `passage.origin.full === document.uri.path` silently misses. This produced duplicate passage records in workspaceState (the dedupe filter in parseRawText failed to evict the old case) and empty filter results in updateDiagnostics and the symbol providers.

2. Reentrancy between onDidOpenTextDocument and changeStoryFormat. The open handler calls changeStoryFormat which calls setTextDocumentLanguage, which closes and reopens the document and fires another onDidOpenTextDocument. Combined with the rename handler also invoking changeStoryFormat concurrently, this could cascade.

Changes:
- utils.ts: add normalizePath / pathsEqual / uriPath helpers that lowercase the Windows drive letter. No-op on other platforms.
- diagnostics.ts, parse-text.ts, passage.ts, extract-passage.ts, file-ops.ts: normalize both sides of every `origin.full` vs `document.uri.path` comparison.
- parse-text.ts: store `origin.full` in normalized form so future compares agree out of the box and the dedupe filter in parseRawText actually matches.
- extension.ts onDidDeleteFiles/onDidRenameFiles: normalized compares so stale passages from startup glob casing get cleaned up/updated.
- extension.ts onDidOpenTextDocument: add a per-document reentrancy guard (Set<string> keyed by normalized URI) so setTextDocumentLanguage-induced reopens cannot cascade into a tight loop.