### PR TITLE
Add widgets defined with <<widget>> to the SugarCube macro list

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To set the correct storyformat for the files, a `StoryData` passage with the sto
 	- Deprecated `<<end...>>` closing macros:  
 		- [Screenshot - diagnostic](docs/images/sc2-endvariant-macro.png)
 		- [Screenshot - quick fix](docs/images/sc2-endvariant-quickfix.png)
-	- Unrecognized macros. New/custom macros can be defined manually (see: [Custom macro definitions for SC](#custom-macro-definitions-for-sugarcube)), but anything else will throw a warning. This can be turned off by the `twee3LanguageTools.sugarcube-2.undefinedMacroWarnings` setting:  
+	- Unrecognized macros. Widgets defined with `<<widget>>` in `widget` tagged passages are picked up from the workspace automatically (see: [Widget definitions](#widget-definitions)). Other custom macros can be defined manually (see: [Custom macro definitions for SC](#custom-macro-definitions-for-sugarcube)), but anything else will throw a warning. This can be turned off by the `twee3LanguageTools.sugarcube-2.undefinedMacroWarnings` setting:  
 		- [Screenshot - diagnostic](docs/images/sc2-unrecognized-macro.png)
 		- [Screenshot - quick fix](docs/images/sc2-unrecognized-quickfix.png) (Writes definitions to `t3lt.twee-config.yml` in the root of the first workspace folder.)
 	- Invalid argument syntax in macros:  
@@ -154,6 +154,26 @@ The fields `description` and `parameters` allow substituting globally defined va
 
 **NOTE:** Multiple `twee-config` files can be present in a workspace. They will stack and add to the macro definitions for the workspace. The recommended strategy is to make separate files for separate macro sets/libraries, e.g. (the following file can also be used as an example):
 - `click-to-proceed.twee-config.yaml` ([Link](https://github.com/cyrusfirheir/cycy-wrote-custom-macros/blob/master/click-to-proceed/click-to-proceed.twee-config.yaml))
+
+---
+
+### Widget definitions
+
+Widgets are already defined in the story itself, so they do not have to be declared a second time. The extension collects the `<<widget "widgetName">>` definitions from every passage tagged `widget` in the workspace and treats them as macro definitions:
+
+```
+:: Widgets [widget]
+
+<<widget "greet">>Well met, _args[0].<</widget>>
+
+<<widget "aside" container>><div class="aside"><<print _contents>></div><</widget>>
+```
+
+`<<greet>>` is then a known macro, and `<<aside>>` a known *container* macro — so an unclosed `<<aside>>` is reported, while neither is reported as unrecognized. Hovering either one shows where it was defined.
+
+Only passages tagged `widget` are read, since SugarCube itself only accepts widget definitions there. Definitions in `twee-config` files win over collected ones, which is the way to add a `description` or `parameters` to a widget. Core SugarCube macros are never overridden, as SugarCube does not allow a widget to clobber one.
+
+This can be turned off with the `twee3LanguageTools.sugarcube-2.features.widgetDefinitions` setting.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -298,6 +298,11 @@
 					"default": true,
 					"markdownDescription": "Highlight opening and closing tags of container macros?"
 				},
+				"twee3LanguageTools.sugarcube-2.features.widgetDefinitions": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "Treat widgets defined with `<<widget>>` in `widget` tagged passages as defined macros? Definitions in `*.twee-config.yaml` or `*.twee-config.json` files take precedence over the collected ones."
+				},
 				"twee3LanguageTools.sugarcube-2.widgetAliases": {
 					"type": "array",
 					"default": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import * as sugarcube2Language from './sugarcube-2/configuration';
 import * as sugarcube2CodeActions from './sugarcube-2/code-actions';
 import { ExtractPassage, extractPassageCommand } from './extract-passage';
 import * as sugarcube2Macros from './sugarcube-2/macros';
+import * as sugarcube2Widgets from './sugarcube-2/widgets';
 import { packer } from './story-map/packer';
 
 import { passageCounter } from './status-bar';
@@ -87,6 +88,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
 
 	function start() {
 		collection.clear();
+		sugarcube2Widgets.clearWidgets();
 		return ctx.workspaceState.update("passages", undefined);
 	}
 
@@ -297,6 +299,9 @@ export async function activate(ctx: vscode.ExtensionContext) {
 			if (e.affectsConfiguration("twee3LanguageTools.directories")) {
 				start().then(prepare);
 			}
+			if (e.affectsConfiguration("twee3LanguageTools.sugarcube-2.features.widgetDefinitions")) {
+				start().then(prepare);
+			}
 			if (e.affectsConfiguration("twee3LanguageTools.sugarcube-2.cache.argumentInformation") && !vscode.workspace.getConfiguration("twee3LanguageTools.sugarcube-2.cache").get(".argumentInformation")) {
 				// The configuration for this setting has been changed and it is now false, so we
 				// clear the cache.
@@ -325,6 +330,14 @@ export async function activate(ctx: vscode.ExtensionContext) {
 		vscode.workspace.onDidDeleteFiles(e => {
 			e.files.forEach(file => sugarcube2Macros.collectCache.clearFilename(file.fsPath));
 
+			const widgetsChanged = e.files
+				.map(file => sugarcube2Widgets.clearFileWidgets(file.path))
+				.some(changed => changed);
+			if (widgetsChanged) {
+				sugarcube2Language.updateConfigurationCache();
+				vscode.commands.executeCommand("twee3LanguageTools.refreshDiagnostics");
+			}
+
 			const removedFilePaths = new Set(e.files.map((file) => normalizePath(file.path)));
 			const oldPassages: Passage[] = getWorkspacePassages(ctx);
 			const newPassages: Passage[] = oldPassages.filter((passage) => !removedFilePaths.has(normalizePath(passage.origin.full)));
@@ -340,6 +353,11 @@ export async function activate(ctx: vscode.ExtensionContext) {
 				await changeStoryFormat(doc);
 
 				sugarcube2Macros.collectCache.clearFilename(file.oldUri.fsPath);
+
+				if (sugarcube2Widgets.clearFileWidgets(file.oldUri.path)) {
+					sugarcube2Language.updateConfigurationCache();
+					vscode.commands.executeCommand("twee3LanguageTools.refreshDiagnostics");
+				}
 
 				const oldPath = normalizePath(file.oldUri.path);
 				const newPath = normalizePath(file.newUri.path);

--- a/src/parse-text.ts
+++ b/src/parse-text.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { getWorkspacePassages, Passage, PassageListProvider } from "./passage";
 import * as sugarcube2Macros from "./sugarcube-2/macros";
 import * as sugarcube2Language from "./sugarcube-2/configuration";
+import * as sugarcube2Widgets from "./sugarcube-2/widgets";
 import { normalizePath } from "./utils";
 
 interface IParsedToken {
@@ -212,6 +213,15 @@ export async function parseRawText(context: vscode.ExtensionContext, document: R
 			Object.assign(newPassage.meta, {
 				wordCount: genericCountWords(passageText),
 			});
+		}
+	}
+
+	if (document.languageId === sugarcube2Language.LanguageID && sugarcube2Widgets.isWidgetCollectionEnabled()) {
+		const widgets = sugarcube2Widgets.collectWidgets(document.text, newPassages);
+		if (sugarcube2Widgets.setFileWidgets(docPath, widgets)) {
+			sugarcube2Language.updateConfigurationCache();
+			// The command does not exist yet during the initial parse, which refreshes anyway.
+			vscode.commands.executeCommand("twee3LanguageTools.refreshDiagnostics").then(undefined, () => { });
 		}
 	}
 

--- a/src/sugarcube-2/configuration.ts
+++ b/src/sugarcube-2/configuration.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as yaml from 'yaml';
 import * as macros from './macros';
 import * as macroListCore from './macros.json';
+import { getWidgetMacros, isWidgetCollectionEnabled } from './widgets';
 
 export const LanguageID = "twee3-sugarcube-2";
 
@@ -75,6 +76,15 @@ export const parseConfiguration = async function (): Promise<Configuration> {
 		macros: Object.assign(Object.create(null), macroListCore),
 		enums: Object.assign(Object.create(null), enumListCore),
 	};
+
+	// Between the core macros and the config files, neither of which a widget may override.
+	if (isWidgetCollectionEnabled()) {
+		const widgetMacros = getWidgetMacros();
+		for (const name in widgetMacros) {
+			if (name in macroListCore) continue;
+			configuration.macros[name] = widgetMacros[name];
+		}
+	}
 
 	const files = vscode.workspace.findFiles("**/*.twee-config.{json,yaml,yml}", "**/{node_modules,.git}/**");
 

--- a/src/sugarcube-2/widgets.ts
+++ b/src/sugarcube-2/widgets.ts
@@ -1,0 +1,152 @@
+import * as vscode from 'vscode';
+
+import { Passage } from '../passage';
+import { normalizePath } from '../utils';
+import type { macroDef, MacroName } from './macros';
+
+export interface CollectedWidget {
+	name: MacroName;
+	container: boolean;
+	passage: string;
+	file: string;
+}
+
+export type WidgetRecord = Record<MacroName, CollectedWidget>;
+
+export const isWidgetCollectionEnabled = function (): boolean {
+	return vscode.workspace.getConfiguration("twee3LanguageTools.sugarcube-2.features").get("widgetDefinitions", true);
+};
+
+/** `<<widget widgetName [container]>>`, the name quoted or not. */
+const widgetDefinitionRegex = /<<widget\s+(?:"([^"\r\n]*)"|'([^'\r\n]*)'|([^\s>]+))([^>]*)>>/g;
+
+const widgetNameRegex = /^[A-Za-z][\w-]*$/;
+
+const WIDGET_TAG = "widget";
+
+/**
+ * Collects the widget definitions from the `widget` tagged passages of a
+ * document. Runs after the passages have been parsed out of it.
+ */
+export const collectWidgets = function (text: string, passages: Passage[]): WidgetRecord {
+	const widgets: WidgetRecord = Object.create(null);
+
+	for (const passage of passages) {
+		if (!passage.tags?.includes(WIDGET_TAG)) continue;
+
+		const content = cleanWidgetText(passage.getContentFromText(text));
+
+		widgetDefinitionRegex.lastIndex = 0;
+		let match: RegExpExecArray | null;
+		while ((match = widgetDefinitionRegex.exec(content)) !== null) {
+			const name = match[1] ?? match[2] ?? match[3];
+			if (!name || !widgetNameRegex.test(name)) continue;
+
+			const container = /(?:^|\s)container(?:\s|$)/.test(match[4] ?? "");
+
+			// Redefining an existing widget is an error in SugarCube, so the first one wins.
+			if (!(name in widgets)) {
+				widgets[name] = { name, container, passage: passage.name, file: passage.origin.full };
+			}
+		}
+	}
+
+	return widgets;
+};
+
+const widgetCleanList = [
+	["/\\*", "\\*/"],
+	["/%", "%/"],
+	["<!--", "-->"],
+	["{{3}", "}{3}"],
+	["\"{3}", "\"{3}"],
+	["<nowiki>", "</nowiki>"],
+	["<script(?:\\s+(?:(?:Twine)|(?:Java))Script)?>", "</script>"],
+	["<style>", "</style>"],
+	["/\\*\\s*@t3lt-parse-off\\s*\\*/", "/\\*\\s*@t3lt-parse-on\\s*\\*/"]
+].map(el => new RegExp(`(${el[0]})((?:.|\r?\n)*?)(${el[1]})`, "gmi"));
+
+/** Hides the `<<widget>>`s which are not definitions, as `collectUncached` does for macros. */
+const cleanWidgetText = function (text: string): string {
+	let cleaned = text;
+	widgetCleanList.forEach(regex => {
+		cleaned = cleaned.replace(regex, (_match, p1, p2, p3) => p1 + p2.replace(/<</g, "MO") + p3);
+	});
+	return cleaned;
+};
+
+/// Keyed by normalized path, as passages are.
+const widgetCache: Map<string, WidgetRecord> = new Map();
+
+const isSameWidget = function (left: CollectedWidget, right: CollectedWidget): boolean {
+	return left.container === right.container && left.passage === right.passage && left.file === right.file;
+};
+
+const areSameWidgets = function (left: WidgetRecord | undefined, right: WidgetRecord): boolean {
+	if (!left) return Object.keys(right).length === 0;
+
+	const leftNames = Object.keys(left);
+	if (leftNames.length !== Object.keys(right).length) return false;
+
+	return leftNames.every(name => name in right && isSameWidget(left[name], right[name]));
+};
+
+/**
+ * Records the widgets of a file.
+ * @returns whether the widgets of the workspace changed.
+ */
+export const setFileWidgets = function (filePath: string, widgets: WidgetRecord): boolean {
+	const path = normalizePath(filePath);
+
+	if (areSameWidgets(widgetCache.get(path), widgets)) return false;
+
+	if (Object.keys(widgets).length) widgetCache.set(path, widgets);
+	else widgetCache.delete(path);
+
+	return true;
+};
+
+/**
+ * Forgets the widgets of a file, for when it is deleted or renamed.
+ * @returns whether the widgets of the workspace changed.
+ */
+export const clearFileWidgets = function (filePath: string): boolean {
+	return widgetCache.delete(normalizePath(filePath));
+};
+
+export const clearWidgets = function (): void {
+	widgetCache.clear();
+};
+
+const widgetDescription = function (widget: CollectedWidget): vscode.MarkdownString {
+	const fileName = widget.file.split("/").pop() || widget.file;
+	const description = new vscode.MarkdownString(
+		`Widget defined in the \`${widget.passage}\` passage of \`${fileName}\`.` +
+		(widget.container ? `\n\nUsage:\n\n\`\`\`\n<<${widget.name}>> … <</${widget.name}>>\n\`\`\`` : "")
+	);
+	description.isTrusted = false;
+	return description;
+};
+
+/**
+ * The collected widgets as macro definitions. Arguments are left unvalidated,
+ * since what a widget takes out of `_args` cannot be known from its definition.
+ */
+export const getWidgetMacros = function (): Record<MacroName, macroDef> {
+	const macros: Record<MacroName, macroDef> = Object.create(null);
+
+	for (const widgets of widgetCache.values()) {
+		for (const name in widgets) {
+			if (name in macros) continue;
+
+			const widget = widgets[name];
+			macros[name] = {
+				name,
+				container: widget.container,
+				description: widgetDescription(widget),
+			};
+		}
+	}
+
+	return macros;
+};

--- a/tests/SugarCube.widgets.tw
+++ b/tests/SugarCube.widgets.tw
@@ -1,0 +1,52 @@
+:: SugarCube widgets [widget] {"position":"950,500"}
+/* widget definition tests */
+
+/* should be collected, and <<greetPlayer>> recognized below */
+<<widget "greetPlayer">>
+	Well met, _args[0].
+<</widget>>
+
+/* barewords are accepted by SugarCube too */
+<<widget barewordWidget>>
+	Beep boop!
+<</widget>>
+
+/* container widget - should require a closing tag where used */
+<<widget "asideBox" container>>
+	<div class="aside"><<print _contents>></div>
+<</widget>>
+
+/* should not be collected: commented out */
+/* <<widget "commentedOutWidget">><</widget>> */
+<!-- <<widget "htmlCommentedWidget">><</widget>> -->
+
+/* should not be collected: verbatim markup */
+{{{<<widget "verbatimWidget">><</widget>>}}}
+
+/* should not be collected: not a usable macro name */
+<<widget "2fast">><</widget>>
+
+
+:: SugarCube widget usage {"position":"1075,500"}
+/* should not throw unrecognized macro warnings */
+<<greetPlayer "Anon">>
+<<barewordWidget>>
+<<asideBox>>Contents.<</asideBox>>
+
+/* should throw a malformed container macro error - no closing tag */
+<<asideBox>>
+
+/* should throw unrecognized macro warnings */
+<<commentedOutWidget>>
+<<htmlCommentedWidget>>
+<<verbatimWidget>>
+<<2fast>>
+
+/* should not be collected: widgets are only read from `widget` tagged passages */
+<<untaggedWidget>>
+
+
+:: SugarCube untagged widget {"position":"1200,500"}
+<<widget "untaggedWidget">>
+	This is an error in SugarCube itself.
+<</widget>>


### PR DESCRIPTION
This _should_ fix warnings thrown for these particular widget macros.

(New to contributing to open-source, also new to Twine, but I am interested in making it more developer-friendly)